### PR TITLE
style: enable tailwind via CDN and refine board layout

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,29 @@
+# Portfolio App Requirements
+
+## Overview
+- Build a lightweight portfolio web application demonstrating TypeScript across both front-end and API layers.
+- Features include a Discord-style board and a contact form.
+
+## Data Models
+- **User**: `id`, `name`, `email`, `hashedPassword`, `createdAt`
+- **Board**: `id`, `title`, `description`, `createdAt`, `createdBy`
+- **Comment**: `id`, `boardId`, `userId`, `body`, `createdAt`
+- **ContactMessage**: `id`, `name`, `email`, `message`, `createdAt`
+
+## REST API Endpoints
+- `GET /api/boards` – list boards
+- `POST /api/boards` – create board
+- `GET /api/boards/:id` – board details with comments
+- `POST /api/boards/:id/comments` – add comment
+- `DELETE /api/comments/:id` – remove comment
+- `POST /api/contact` – send contact message
+
+## Front-end
+- Single Page Application using TypeScript and Vue/Nuxt.
+- Board interface inspired by Discord with a sidebar of posts and inline comment view.
+- Contact page for submitting inquiries.
+
+## Non-functional
+- Emphasize type safety, unit tests, and CI/CD pipeline.
+- Deployment target: AWS (specific service TBD).
+

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,6 +2,9 @@ export default defineNuxtConfig({
   ssr: true,
   target: 'static',
   app: {
-    baseURL: '/my-portfolio/'
+    baseURL: '/my-portfolio/',
+    head: {
+      script: [{ src: 'https://cdn.tailwindcss.com' }]
+    }
   }
 })

--- a/pages/board/index.vue
+++ b/pages/board/index.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="flex h-screen text-sm">
+    <aside class="w-64 bg-gray-900 text-gray-100 p-4 space-y-2">
+      <h2 class="text-xl font-bold mb-4">掲示板</h2>
+      <ul class="space-y-1">
+        <li
+          v-for="post in posts"
+          :key="post.id"
+          @click="selectPost(post)"
+          :class="[
+            'p-2 rounded cursor-pointer hover:bg-gray-800',
+            post.id === activePost?.id ? 'bg-gray-800' : ''
+          ]"
+        >
+          # {{ post.title }}
+        </li>
+      </ul>
+    </aside>
+    <main class="flex-1 bg-gray-700 text-white flex flex-col">
+      <div class="flex justify-end space-x-4 p-4 border-b border-gray-600">
+        <NuxtLink to="/signup" class="hover:underline">会員登録</NuxtLink>
+        <NuxtLink to="/login" class="hover:underline">ログイン</NuxtLink>
+        <NuxtLink to="/mypage" class="hover:underline">マイページ</NuxtLink>
+      </div>
+      <div v-if="activePost" class="flex-1 overflow-y-auto p-4">
+        <h3 class="text-2xl font-bold mb-2">{{ activePost.title }}</h3>
+        <ul class="space-y-2 mb-4">
+          <li
+            v-for="c in comments[activePost.id]"
+            :key="c.id"
+            class="bg-gray-800 p-3 rounded"
+          >
+            <p>{{ c.body }}</p>
+          </li>
+        </ul>
+      </div>
+      <div v-else class="flex-1 flex items-center justify-center text-gray-400">
+        投稿を選択してください
+      </div>
+      <form
+        v-if="activePost"
+        @submit.prevent="addComment"
+        class="p-4 border-t border-gray-600 flex"
+      >
+        <input
+          v-model="newComment"
+          class="flex-1 p-2 rounded bg-gray-800 text-white placeholder-gray-400 mr-2"
+          placeholder="メッセージを入力"
+        />
+        <button type="submit" class="px-4 bg-blue-500 text-white rounded">
+          投稿
+        </button>
+      </form>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref } from 'vue'
+
+interface Post { id: number; title: string }
+interface Comment { id: number; postId: number; body: string }
+
+const posts = reactive<Post[]>([
+  { id: 1, title: '最初の投稿' },
+  { id: 2, title: 'Nuxt 3 について語ろう' }
+])
+
+const comments = reactive<Record<number, Comment[]>>({
+  1: [{ id: 1, postId: 1, body: 'こんにちは！' }],
+  2: []
+})
+
+const activePost = ref<Post | null>(null)
+const newComment = ref('')
+
+function selectPost(post: Post) {
+  activePost.value = post
+}
+
+function addComment() {
+  if (!activePost.value || !newComment.value.trim()) return
+  const postId = activePost.value.id
+  const list = comments[postId] || (comments[postId] = [])
+  list.push({ id: Date.now(), postId, body: newComment.value })
+  newComment.value = ''
+}
+</script>
+
+<style scoped>
+</style>

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -1,0 +1,38 @@
+<template>
+  <main class="min-h-screen bg-gray-100 p-8">
+    <div class="max-w-xl mx-auto bg-white p-6 rounded-xl shadow-md">
+      <h1 class="text-2xl font-bold mb-4">お問い合わせ</h1>
+      <form @submit.prevent="submit">
+        <div class="mb-4">
+          <label class="block text-sm font-medium mb-1">名前</label>
+          <input v-model="form.name" type="text" class="w-full border rounded p-2" required />
+        </div>
+        <div class="mb-4">
+          <label class="block text-sm font-medium mb-1">メールアドレス</label>
+          <input v-model="form.email" type="email" class="w-full border rounded p-2" required />
+        </div>
+        <div class="mb-4">
+          <label class="block text-sm font-medium mb-1">メッセージ</label>
+          <textarea v-model="form.message" class="w-full border rounded p-2" rows="4" required></textarea>
+        </div>
+        <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded" :disabled="sent">
+          送信
+        </button>
+        <p v-if="sent" class="text-green-600 mt-2">送信しました！</p>
+      </form>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref } from 'vue';
+import type { ContactMessage } from '~/types/contact';
+
+const form = reactive<ContactMessage>({ name: '', email: '', message: '' });
+const sent = ref(false);
+
+const submit = async () => {
+  await $fetch('/api/contact', { method: 'POST', body: form });
+  sent.value = true;
+};
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,6 +3,20 @@
     <div class="max-w-3xl mx-auto text-center">
       <h1 class="text-4xl font-bold">ムカイ / Mukai</h1>
       <p class="text-gray-600 mt-2">Nuxt × TypeScript のフリーランスエンジニア</p>
+      <div class="mt-4 flex justify-center space-x-6">
+        <NuxtLink
+          to="/contact"
+          class="text-blue-500 underline"
+        >
+          お問い合わせ
+        </NuxtLink>
+        <NuxtLink
+          to="/board"
+          class="text-blue-500 underline"
+        >
+          掲示板
+        </NuxtLink>
+      </div>
 
       <div class="mt-10 grid gap-6 grid-cols-1 sm:grid-cols-2">
         <NuxtLink

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,0 +1,8 @@
+<template>
+  <main class="min-h-screen flex items-center justify-center bg-gray-100">
+    <div class="text-center">
+      <h1 class="text-2xl font-bold">ログイン</h1>
+      <p class="mt-4 text-gray-600">このページは作成中です。</p>
+    </div>
+  </main>
+</template>

--- a/pages/mypage.vue
+++ b/pages/mypage.vue
@@ -1,0 +1,8 @@
+<template>
+  <main class="min-h-screen flex items-center justify-center bg-gray-100">
+    <div class="text-center">
+      <h1 class="text-2xl font-bold">マイページ</h1>
+      <p class="mt-4 text-gray-600">このページは作成中です。</p>
+    </div>
+  </main>
+</template>

--- a/pages/signup.vue
+++ b/pages/signup.vue
@@ -1,0 +1,8 @@
+<template>
+  <main class="min-h-screen flex items-center justify-center bg-gray-100">
+    <div class="text-center">
+      <h1 class="text-2xl font-bold">会員登録</h1>
+      <p class="mt-4 text-gray-600">このページは作成中です。</p>
+    </div>
+  </main>
+</template>

--- a/server/api/contact.post.ts
+++ b/server/api/contact.post.ts
@@ -1,0 +1,14 @@
+import type { ContactMessage } from '~/types/contact';
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event);
+  const { name, email, message } = body as Partial<ContactMessage>;
+
+  if (!name || !email || !message) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid payload' });
+  }
+
+  console.log('Received contact message', { name, email, message });
+
+  return { success: true };
+});

--- a/types/contact.ts
+++ b/types/contact.ts
@@ -1,0 +1,5 @@
+export interface ContactMessage {
+  name: string;
+  email: string;
+  message: string;
+}


### PR DESCRIPTION
## Summary
- load Tailwind CSS from CDN for styling across pages
- restyle board page with Discord-like layout and message input
- center placeholder auth pages with Tailwind utilities

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b13d4f98ac832e9a082bc3ef0e1c32