### PR TITLE
feat: add login page and API

### DIFF
--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,6 +1,52 @@
 <template>
-  <div class="p-8 text-center">
-    <h1 class="text-2xl font-bold">ログイン</h1>
-    <p class="mt-4 text-gray-600">このページは作成中です。</p>
+  <div class="max-w-md mx-auto p-8">
+    <h1 class="text-2xl font-bold text-center mb-6">ログイン</h1>
+    <form @submit.prevent="onSubmit" class="space-y-4">
+      <div>
+        <input
+          v-model="email"
+          type="email"
+          placeholder="メールアドレス"
+          class="border rounded w-full p-2"
+        />
+      </div>
+      <div>
+        <input
+          v-model="password"
+          type="password"
+          placeholder="パスワード"
+          class="border rounded w-full p-2"
+        />
+      </div>
+      <div v-if="error" class="text-red-500 text-sm">{{ error }}</div>
+      <button type="submit" class="w-full bg-blue-500 text-white py-2 rounded">
+        ログイン
+      </button>
+    </form>
   </div>
 </template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { LoginResponse } from '~/types/auth'
+
+const email = ref('')
+const password = ref('')
+const error = ref('')
+
+async function onSubmit() {
+  try {
+    const data = await $fetch<LoginResponse>('/api/login', {
+      method: 'POST',
+      body: { email: email.value, password: password.value }
+    })
+    const token = useCookie('token')
+    token.value = data.token
+    await navigateTo('/board')
+  } catch (e) {
+    error.value = 'メールアドレスまたはパスワードが正しくありません。'
+  }
+}
+</script>
+
+<style scoped></style>

--- a/server/api/login.post.ts
+++ b/server/api/login.post.ts
@@ -1,0 +1,24 @@
+import type { LoginCredentials, LoginResponse } from '~/types/auth';
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event);
+  const { email, password } = body as Partial<LoginCredentials>;
+
+  if (!email || !password) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid payload' });
+  }
+
+  // Simple credential check; in real application use proper authentication
+  if (email === 'user@example.com' && password === 'password') {
+    const token = 'dummy-token';
+    setCookie(event, 'token', token, {
+      httpOnly: true,
+      path: '/',
+      maxAge: 60 * 60, // 1 hour
+    });
+    const res: LoginResponse = { token };
+    return res;
+  }
+
+  throw createError({ statusCode: 401, statusMessage: 'Invalid credentials' });
+});

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -1,0 +1,8 @@
+export interface LoginCredentials {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  token: string;
+}


### PR DESCRIPTION
## Summary
- implement login page with form and cookie-based auth
- add login API endpoint and auth types

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4210313f48326a786c6b61f50923b