### PR TITLE
feat: add pokeca inventory management

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "nuxt": "^3.17.2",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "better-sqlite3": "^9.0.0"
   }
 }

--- a/pages/cards/[id].vue
+++ b/pages/cards/[id].vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import type { Card, CardPayload } from '~/types/card';
+
+const route = useRoute();
+const id = Number(route.params.id);
+const { data } = await useFetch<Card>(`/api/cards/${id}`);
+
+const form = reactive<CardPayload>({
+  name: data.value?.name || '',
+  setName: data.value?.setName || '',
+  rarity: data.value?.rarity || '',
+  quantity: data.value?.quantity || 0,
+  price: data.value?.price || 0
+});
+
+async function submit() {
+  await $fetch(`/api/cards/${id}`, { method: 'PUT', body: form });
+  await navigateTo('/cards');
+}
+</script>
+
+<template>
+  <div class="p-4">
+    <h1 class="text-2xl mb-4">Edit Card</h1>
+    <form @submit.prevent="submit" class="space-y-2">
+      <div>
+        <label class="block">Name</label>
+        <input v-model="form.name" class="border p-1 w-full" required />
+      </div>
+      <div>
+        <label class="block">Set</label>
+        <input v-model="form.setName" class="border p-1 w-full" />
+      </div>
+      <div>
+        <label class="block">Rarity</label>
+        <input v-model="form.rarity" class="border p-1 w-full" />
+      </div>
+      <div>
+        <label class="block">Quantity</label>
+        <input type="number" v-model.number="form.quantity" class="border p-1 w-full" />
+      </div>
+      <div>
+        <label class="block">Price</label>
+        <input type="number" step="0.01" v-model.number="form.price" class="border p-1 w-full" />
+      </div>
+      <button type="submit" class="bg-blue-600 text-white px-4 py-1">Save</button>
+    </form>
+  </div>
+</template>

--- a/pages/cards/index.vue
+++ b/pages/cards/index.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import type { Card } from '~/types/card';
+
+const { data: cards, refresh } = await useFetch<Card[]>('/api/cards');
+
+async function remove(id: number) {
+  await $fetch(`/api/cards/${id}`, { method: 'DELETE' });
+  await refresh();
+}
+</script>
+
+<template>
+  <div class="p-4">
+    <h1 class="text-2xl mb-4">Card Inventory</h1>
+    <NuxtLink to="/cards/new" class="text-blue-600 underline">Register Card</NuxtLink>
+    <table class="w-full mt-4 border-collapse">
+      <thead>
+        <tr>
+          <th class="border p-2">Name</th>
+          <th class="border p-2">Set</th>
+          <th class="border p-2">Rarity</th>
+          <th class="border p-2">Quantity</th>
+          <th class="border p-2">Price</th>
+          <th class="border p-2"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="card in cards" :key="card.id">
+          <td class="border p-2">{{ card.name }}</td>
+          <td class="border p-2">{{ card.setName }}</td>
+          <td class="border p-2">{{ card.rarity }}</td>
+          <td class="border p-2">{{ card.quantity }}</td>
+          <td class="border p-2">{{ card.price }}</td>
+          <td class="border p-2">
+            <NuxtLink :to="`/cards/${card.id}`" class="text-blue-600 mr-2">Edit</NuxtLink>
+            <button class="text-red-600" @click="remove(card.id)">Delete</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/pages/cards/new.vue
+++ b/pages/cards/new.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import type { CardPayload } from '~/types/card';
+
+const form = reactive<CardPayload>({
+  name: '',
+  setName: '',
+  rarity: '',
+  quantity: 0,
+  price: 0
+});
+
+async function submit() {
+  await $fetch('/api/cards', { method: 'POST', body: form });
+  await navigateTo('/cards');
+}
+</script>
+
+<template>
+  <div class="p-4">
+    <h1 class="text-2xl mb-4">Register Card</h1>
+    <form @submit.prevent="submit" class="space-y-2">
+      <div>
+        <label class="block">Name</label>
+        <input v-model="form.name" class="border p-1 w-full" required />
+      </div>
+      <div>
+        <label class="block">Set</label>
+        <input v-model="form.setName" class="border p-1 w-full" />
+      </div>
+      <div>
+        <label class="block">Rarity</label>
+        <input v-model="form.rarity" class="border p-1 w-full" />
+      </div>
+      <div>
+        <label class="block">Quantity</label>
+        <input type="number" v-model.number="form.quantity" class="border p-1 w-full" />
+      </div>
+      <div>
+        <label class="block">Price</label>
+        <input type="number" step="0.01" v-model.number="form.price" class="border p-1 w-full" />
+      </div>
+      <button type="submit" class="bg-blue-600 text-white px-4 py-1">Save</button>
+    </form>
+  </div>
+</template>

--- a/server/api/cards/[id]/index.delete.ts
+++ b/server/api/cards/[id]/index.delete.ts
@@ -1,0 +1,8 @@
+import db from '~/server/db';
+
+export default defineEventHandler((event) => {
+  const id = Number(event.context.params!.id);
+  const stmt = db.prepare('DELETE FROM cards WHERE id = ?');
+  stmt.run(id);
+  return { success: true };
+});

--- a/server/api/cards/[id]/index.get.ts
+++ b/server/api/cards/[id]/index.get.ts
@@ -1,0 +1,8 @@
+import db from '~/server/db';
+import type { Card } from '~/types/card';
+
+export default defineEventHandler((event) => {
+  const id = Number(event.context.params!.id);
+  const stmt = db.prepare<Card>('SELECT * FROM cards WHERE id = ?');
+  return stmt.get(id);
+});

--- a/server/api/cards/[id]/index.put.ts
+++ b/server/api/cards/[id]/index.put.ts
@@ -1,0 +1,19 @@
+import db from '~/server/db';
+import type { CardPayload } from '~/types/card';
+
+export default defineEventHandler(async (event) => {
+  const id = Number(event.context.params!.id);
+  const body = await readBody<CardPayload>(event);
+  const stmt = db.prepare(
+    'UPDATE cards SET name = ?, setName = ?, rarity = ?, quantity = ?, price = ? WHERE id = ?'
+  );
+  stmt.run(
+    body.name,
+    body.setName ?? null,
+    body.rarity ?? null,
+    body.quantity,
+    body.price,
+    id
+  );
+  return { success: true };
+});

--- a/server/api/cards/index.get.ts
+++ b/server/api/cards/index.get.ts
@@ -1,0 +1,7 @@
+import db from '~/server/db';
+import type { Card } from '~/types/card';
+
+export default defineEventHandler(() => {
+  const stmt = db.prepare<Card>('SELECT * FROM cards ORDER BY id DESC');
+  return stmt.all();
+});

--- a/server/api/cards/index.post.ts
+++ b/server/api/cards/index.post.ts
@@ -1,0 +1,17 @@
+import db from '~/server/db';
+import type { CardPayload } from '~/types/card';
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody<CardPayload>(event);
+  const stmt = db.prepare(
+    'INSERT INTO cards (name, setName, rarity, quantity, price) VALUES (?, ?, ?, ?, ?)'
+  );
+  const info = stmt.run(
+    body.name,
+    body.setName ?? null,
+    body.rarity ?? null,
+    body.quantity,
+    body.price
+  );
+  return { id: Number(info.lastInsertRowid) };
+});

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,0 +1,18 @@
+import Database from 'better-sqlite3';
+import { join } from 'path';
+
+const dbFile = join(process.cwd(), 'cards.db');
+const db = new Database(dbFile);
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS cards (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    setName TEXT,
+    rarity TEXT,
+    quantity INTEGER DEFAULT 0,
+    price REAL DEFAULT 0
+  )
+`);
+
+export default db;

--- a/types/card.ts
+++ b/types/card.ts
@@ -1,0 +1,11 @@
+export interface CardPayload {
+  name: string;
+  setName?: string;
+  rarity?: string;
+  quantity: number;
+  price: number;
+}
+
+export interface Card extends CardPayload {
+  id: number;
+}


### PR DESCRIPTION
## Summary
- add SQLite-backed DB and API for Pokémon cards
- implement pages to register, list, edit and delete cards
- introduce card types for type safety

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b51594b2c08326b01060543ce7cccb