### PR TITLE
feat(board): add page for creating posts

### DIFF
--- a/pages/board/index.vue
+++ b/pages/board/index.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="flex h-screen bg-[#36393f] text-gray-200">
-    <aside class="w-60 bg-[#2f3136] p-4 space-y-2">
+    <aside class="w-60 bg-[#2f3136] p-4 flex flex-col">
       <h2 class="text-xl font-semibold mb-4">掲示板</h2>
-      <ul class="space-y-1">
+      <ul class="space-y-1 flex-1 overflow-y-auto">
         <li
           v-for="post in posts"
           :key="post.id"
@@ -15,6 +15,12 @@
           # {{ post.title }}
         </li>
       </ul>
+      <NuxtLink
+        to="/board/new"
+        class="mt-4 px-2 py-1 text-center bg-[#5865F2] text-white rounded hover:bg-[#4752C4]"
+      >
+        新規投稿
+      </NuxtLink>
     </aside>
     <main class="flex-1 flex flex-col bg-[#36393f]">
       <header class="h-12 px-4 flex items-center shadow">
@@ -60,20 +66,20 @@
 </template>
 
 <script setup lang="ts">
-import { reactive, ref } from 'vue'
+import { ref } from 'vue'
 
 interface Post { id: number; title: string }
 interface Comment { id: number; postId: number; body: string }
 
-const posts = reactive<Post[]>([
+const posts = useState<Post[]>('posts', () => [
   { id: 1, title: '最初の投稿' },
   { id: 2, title: 'Nuxt 3 について語ろう' }
 ])
 
-const comments = reactive<Record<number, Comment[]>>({
+const comments = useState<Record<number, Comment[]>>('comments', () => ({
   1: [{ id: 1, postId: 1, body: 'こんにちは！' }],
   2: []
-})
+}))
 
 const activePost = ref<Post | null>(null)
 const newComment = ref('')
@@ -85,7 +91,7 @@ function selectPost(post: Post) {
 function addComment() {
   if (!activePost.value || !newComment.value.trim()) return
   const postId = activePost.value.id
-  const list = comments[postId] || (comments[postId] = [])
+  const list = comments.value[postId] || (comments.value[postId] = [])
   list.push({ id: Date.now(), postId, body: newComment.value })
   newComment.value = ''
 }

--- a/pages/board/new.vue
+++ b/pages/board/new.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="h-screen bg-[#36393f] flex items-center justify-center text-gray-200">
+    <form @submit.prevent="createPost" class="bg-[#2f3136] p-6 rounded space-y-4 w-full max-w-md">
+      <h2 class="text-xl font-semibold">新規投稿</h2>
+      <div>
+        <label class="block mb-1">タイトル</label>
+        <input
+          v-model="title"
+          required
+          class="w-full p-2 rounded bg-[#202225] text-gray-200 focus:outline-none"
+        />
+      </div>
+      <div>
+        <label class="block mb-1">最初のコメント (任意)</label>
+        <textarea
+          v-model="body"
+          class="w-full p-2 rounded bg-[#202225] text-gray-200 focus:outline-none"
+        ></textarea>
+      </div>
+      <div class="flex justify-end space-x-2">
+        <NuxtLink to="/board" class="px-4 py-2 bg-gray-500 rounded text-white">キャンセル</NuxtLink>
+        <button type="submit" class="px-4 py-2 bg-[#5865F2] rounded text-white">投稿</button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+interface Post { id: number; title: string }
+interface Comment { id: number; postId: number; body: string }
+
+const posts = useState<Post[]>('posts', () => [])
+const comments = useState<Record<number, Comment[]>>('comments', () => ({}))
+
+const title = ref('')
+const body = ref('')
+
+const router = useRouter()
+
+function createPost() {
+  if (!title.value.trim()) return
+  const id = Date.now()
+  posts.value.push({ id, title: title.value })
+  comments.value[id] = []
+  if (body.value.trim()) {
+    comments.value[id].push({ id: Date.now(), postId: id, body: body.value })
+  }
+  router.push('/board')
+}
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
## Summary
- allow creating new posts with an optional first comment
- add sidebar button and shared state for board posts

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b518c8d89c8326849112556d120428