### PR TITLE
feat(board): persist posts with sqlite

### DIFF
--- a/pages/board/index.vue
+++ b/pages/board/index.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="flex h-screen bg-[#36393f] text-gray-200">
-    <aside class="w-60 bg-[#2f3136] p-4 space-y-2">
+    <aside class="w-60 bg-[#2f3136] p-4 flex flex-col">
       <h2 class="text-xl font-semibold mb-4">掲示板</h2>
-      <ul class="space-y-1">
+      <ul class="space-y-1 flex-1 overflow-y-auto">
         <li
           v-for="post in posts"
           :key="post.id"
@@ -15,6 +15,12 @@
           # {{ post.title }}
         </li>
       </ul>
+      <NuxtLink
+        to="/board/new"
+        class="mt-4 px-2 py-1 text-center bg-[#5865F2] text-white rounded hover:bg-[#4752C4]"
+      >
+        新規投稿
+      </NuxtLink>
     </aside>
     <main class="flex-1 flex flex-col bg-[#36393f]">
       <header class="h-12 px-4 flex items-center shadow">
@@ -31,7 +37,7 @@
       <section class="flex-1 overflow-y-auto p-4 space-y-4">
         <ul v-if="activePost" class="space-y-4">
           <li
-            v-for="c in comments[activePost.id]"
+            v-for="c in comments"
             :key="c.id"
             class="flex items-start space-x-2"
           >
@@ -60,35 +66,35 @@
 </template>
 
 <script setup lang="ts">
-import { reactive, ref } from 'vue'
+import { ref, onMounted } from 'vue'
+import type { Post, Comment } from '~/types/board'
 
-interface Post { id: number; title: string }
-interface Comment { id: number; postId: number; body: string }
-
-const posts = reactive<Post[]>([
-  { id: 1, title: '最初の投稿' },
-  { id: 2, title: 'Nuxt 3 について語ろう' }
-])
-
-const comments = reactive<Record<number, Comment[]>>({
-  1: [{ id: 1, postId: 1, body: 'こんにちは！' }],
-  2: []
-})
-
+const posts = ref<Post[]>([])
+const comments = ref<Comment[]>([])
 const activePost = ref<Post | null>(null)
 const newComment = ref('')
 
-function selectPost(post: Post) {
-  activePost.value = post
+async function fetchPosts() {
+  posts.value = await $fetch<Post[]>('/api/board/posts')
 }
 
-function addComment() {
+async function selectPost(post: Post) {
+  activePost.value = post
+  comments.value = await $fetch<Comment[]>(`/api/board/posts/${post.id}/comments`)
+}
+
+async function addComment() {
   if (!activePost.value || !newComment.value.trim()) return
   const postId = activePost.value.id
-  const list = comments[postId] || (comments[postId] = [])
-  list.push({ id: Date.now(), postId, body: newComment.value })
+  await $fetch(`/api/board/posts/${postId}/comments`, {
+    method: 'POST',
+    body: { body: newComment.value }
+  })
+  comments.value = await $fetch<Comment[]>(`/api/board/posts/${postId}/comments`)
   newComment.value = ''
 }
+
+onMounted(fetchPosts)
 </script>
 
 <style scoped>

--- a/pages/board/new.vue
+++ b/pages/board/new.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="h-screen bg-[#36393f] flex items-center justify-center text-gray-200">
+    <form @submit.prevent="createPost" class="bg-[#2f3136] p-6 rounded space-y-4 w-full max-w-md">
+      <h2 class="text-xl font-semibold">新規投稿</h2>
+      <div>
+        <label class="block mb-1">タイトル</label>
+        <input
+          v-model="title"
+          required
+          class="w-full p-2 rounded bg-[#202225] text-gray-200 focus:outline-none"
+        />
+      </div>
+      <div>
+        <label class="block mb-1">最初のコメント (任意)</label>
+        <textarea
+          v-model="body"
+          class="w-full p-2 rounded bg-[#202225] text-gray-200 focus:outline-none"
+        ></textarea>
+      </div>
+      <div class="flex justify-end space-x-2">
+        <NuxtLink to="/board" class="px-4 py-2 bg-gray-500 rounded text-white">キャンセル</NuxtLink>
+        <button type="submit" class="px-4 py-2 bg-[#5865F2] rounded text-white">投稿</button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const title = ref('')
+const body = ref('')
+
+const router = useRouter()
+
+async function createPost() {
+  if (!title.value.trim()) return
+  await $fetch('/api/board/posts', {
+    method: 'POST',
+    body: { title: title.value, body: body.value }
+  })
+  router.push('/board')
+}
+</script>
+
+<style scoped></style>

--- a/server/api/board/posts/[id]/comments/index.get.ts
+++ b/server/api/board/posts/[id]/comments/index.get.ts
@@ -1,0 +1,8 @@
+import db from '~/server/db';
+import type { Comment } from '~/types/board';
+
+export default defineEventHandler((event) => {
+  const postId = Number(event.context.params!.id);
+  const stmt = db.prepare<Comment>('SELECT * FROM comments WHERE postId = ? ORDER BY id');
+  return stmt.all(postId);
+});

--- a/server/api/board/posts/[id]/comments/index.post.ts
+++ b/server/api/board/posts/[id]/comments/index.post.ts
@@ -1,0 +1,9 @@
+import db from '~/server/db';
+
+export default defineEventHandler(async (event) => {
+  const postId = Number(event.context.params!.id);
+  const body = await readBody<{ body: string }>(event);
+  const stmt = db.prepare('INSERT INTO comments (postId, body) VALUES (?, ?)');
+  const info = stmt.run(postId, body.body);
+  return { id: Number(info.lastInsertRowid) };
+});

--- a/server/api/board/posts/index.get.ts
+++ b/server/api/board/posts/index.get.ts
@@ -1,0 +1,7 @@
+import db from '~/server/db';
+import type { Post } from '~/types/board';
+
+export default defineEventHandler(() => {
+  const stmt = db.prepare<Post>('SELECT * FROM posts ORDER BY id DESC');
+  return stmt.all();
+});

--- a/server/api/board/posts/index.post.ts
+++ b/server/api/board/posts/index.post.ts
@@ -1,0 +1,12 @@
+import db from '~/server/db';
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody<{ title: string; body?: string }>(event);
+  const postStmt = db.prepare('INSERT INTO posts (title) VALUES (?)');
+  const info = postStmt.run(body.title);
+  if (body.body && body.body.trim()) {
+    const commentStmt = db.prepare('INSERT INTO comments (postId, body) VALUES (?, ?)');
+    commentStmt.run(info.lastInsertRowid, body.body);
+  }
+  return { id: Number(info.lastInsertRowid) };
+});

--- a/server/db.ts
+++ b/server/db.ts
@@ -12,7 +12,19 @@ db.exec(`
     rarity TEXT,
     quantity INTEGER DEFAULT 0,
     price REAL DEFAULT 0
-  )
+  );
+
+  CREATE TABLE IF NOT EXISTS posts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS comments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    postId INTEGER NOT NULL,
+    body TEXT NOT NULL,
+    FOREIGN KEY (postId) REFERENCES posts(id) ON DELETE CASCADE
+  );
 `);
 
 export default db;

--- a/types/board.ts
+++ b/types/board.ts
@@ -1,0 +1,16 @@
+export interface PostPayload {
+  title: string;
+}
+
+export interface Post extends PostPayload {
+  id: number;
+}
+
+export interface CommentPayload {
+  postId: number;
+  body: string;
+}
+
+export interface Comment extends CommentPayload {
+  id: number;
+}


### PR DESCRIPTION
## Summary
- store board posts and comments in SQLite tables
- add API endpoints for posts and comments
- fetch and save board data through these endpoints

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b518c8d89c8326849112556d120428