### PR TITLE
fix: remove duplicate board state

### DIFF
--- a/pages/board/index.vue
+++ b/pages/board/index.vue
@@ -74,12 +74,6 @@ const comments = ref<Comment[]>([])
 const activePost = ref<Post | null>(null)
 const newComment = ref('')
 
-
-const posts = ref<Post[]>([])
-const comments = ref<Comment[]>([])
-const activePost = ref<Post | null>(null)
-const newComment = ref('')
-
 async function fetchPosts() {
   posts.value = await $fetch<Post[]>('/api/board/posts')
 }


### PR DESCRIPTION
## Summary
- remove duplicate refs in board page to resolve build conflict

## Testing
- `npm run generate`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5353d47d08326973da11138337982