### PR TITLE
Use avatar image and orange accent on landing page

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,15 +2,15 @@
   <main class="min-h-screen bg-gray-100 p-8">
     <div class="max-w-4xl mx-auto">
       <div class="text-center">
-        <img src="/logo.svg" alt="Logo" class="mx-auto mb-4 w-24 h-24" />
-        <h1 class="text-4xl font-bold text-indigo-600">Kengo Mukai</h1>
+        <img src="/avatar.png" alt="Avatar" class="mx-auto mb-4 w-24 h-24" />
+        <h1 class="text-4xl font-bold text-orange-600">Kengo Mukai</h1>
         <p class="text-gray-700 mt-2">NuxtとTypeScriptで心地よいWeb体験を。</p>
       </div>
 
       <div class="mt-10 grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
         <NuxtLink
           to="/board"
-          class="bg-white border-t-4 border-indigo-400 shadow-md p-6 rounded-xl hover:bg-indigo-50 hover:-translate-y-1 hover:shadow-xl transition-transform transform"
+          class="bg-white border-t-4 border-orange-400 shadow-md p-6 rounded-xl hover:bg-orange-50 hover:-translate-y-1 hover:shadow-xl transition-transform transform"
         >
           <h2 class="text-xl font-semibold">掲示板</h2>
           <p class="text-sm text-gray-500 mt-1">コミュニティで意見交換</p>
@@ -18,7 +18,7 @@
 
         <NuxtLink
           to="/projects/weathermood"
-          class="bg-white border-t-4 border-indigo-400 shadow-md p-6 rounded-xl hover:bg-indigo-50 hover:-translate-y-1 hover:shadow-xl transition-transform transform"
+          class="bg-white border-t-4 border-orange-400 shadow-md p-6 rounded-xl hover:bg-orange-50 hover:-translate-y-1 hover:shadow-xl transition-transform transform"
         >
           <h2 class="text-xl font-semibold">WeatherMood</h2>
           <p class="text-sm text-gray-500 mt-1">天気×気分UIで魅せるTypeScript作品</p>
@@ -26,15 +26,15 @@
 
         <NuxtLink
           to="/projects/pokemon"
-          class="bg-white border-t-4 border-indigo-400 shadow-md p-6 rounded-xl hover:bg-indigo-50 hover:-translate-y-1 hover:shadow-xl transition-transform transform"
+          class="bg-white border-t-4 border-orange-400 shadow-md p-6 rounded-xl hover:bg-orange-50 hover:-translate-y-1 hover:shadow-xl transition-transform transform"
         >
           <h2 class="text-xl font-semibold">ポケカ在庫管理</h2>
           <p class="text-sm text-gray-500 mt-1">SQLite×TSでローカル管理アプリ</p>
         </NuxtLink>
       </div>
 
-      <div class="mt-12 max-w-xl mx-auto bg-white p-6 rounded-xl shadow-md border-t-4 border-indigo-400">
-        <h2 class="text-2xl font-bold mb-4 text-center text-indigo-600">お問い合わせ</h2>
+      <div class="mt-12 max-w-xl mx-auto bg-white p-6 rounded-xl shadow-md border-t-4 border-orange-400">
+        <h2 class="text-2xl font-bold mb-4 text-center text-orange-600">お問い合わせ</h2>
         <form @submit.prevent="submit" class="space-y-4">
           <div>
             <label class="block text-sm font-medium mb-1">名前</label>
@@ -51,7 +51,7 @@
           <!-- Honeypot field for bots -->
           <input v-model="form.botField" type="text" class="hidden" tabindex="-1" autocomplete="off" />
           <div class="text-center">
-            <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded" :disabled="sent">
+            <button type="submit" class="bg-orange-500 text-white px-4 py-2 rounded" :disabled="sent">
               送信
             </button>
           </div>


### PR DESCRIPTION
## Summary
- Display `avatar.png` on the landing page
- Switch primary accent color to orange for headings, cards, and contact form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: nuxt: not found; `npm install` failed with E403)*

------
https://chatgpt.com/codex/tasks/task_e_68b5413f8f648326837f08b15fc5b541