### PR TITLE
Add Node-based test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,13 @@ bun run preview
 
 Nuxt のより詳しいデプロイ方法は [公式ドキュメント](https://nuxt.com/docs/getting-started/deployment) を参照してください。
 
+## テスト
+
+単体テストを実行するには、次のコマンドを実行します。
+
+```bash
+npm test
+```
+
+Node.js の組み込みテストランナーを使用しており、追加の依存関係は不要です。
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare"
+    "postinstall": "nuxt prepare",
+    "test": "node --test"
   },
   "dependencies": {
     "nuxt": "^3.17.2",

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,0 +1,8 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Basic sample test to ensure test runner works
+
+test('adds numbers correctly', () => {
+  assert.equal(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary
- add `npm test` script using Node's built-in test runner
- document how to run the tests in README
- include a sample test file exercising the runner

## Testing
- `npm test`
- `npm run build` (fails: nuxt: not found)

------
https://chatgpt.com/codex/tasks/task_e_68b54330a7e0832687966b598f3bd39e