### PR TITLE
Add Pomodoro timer page

### DIFF
--- a/components/LinkCard.vue
+++ b/components/LinkCard.vue
@@ -1,0 +1,16 @@
+<template>
+  <NuxtLink
+    :to="to"
+    class="bg-white border-t-4 border-orange-400 shadow-md p-6 rounded-xl hover:bg-orange-50 hover:-translate-y-1 hover:shadow-xl transition-transform transform flex justify-between items-center"
+  >
+    <div>
+      <h2 class="text-xl font-semibold">{{ title }}</h2>
+      <p class="text-sm text-gray-500 mt-1">{{ summary }}</p>
+    </div>
+    <span aria-hidden="true" class="text-orange-400 text-2xl">→</span>
+  </NuxtLink>
+</template>
+
+<script setup lang="ts">
+defineProps<{ to: string; title: string; summary: string }>();
+</script>

--- a/composables/usePomodoroTimer.ts
+++ b/composables/usePomodoroTimer.ts
@@ -1,0 +1,154 @@
+import { ref, computed, onMounted, onUnmounted } from 'vue';
+
+export const usePomodoroTimer = () => {
+  const workMinutes = ref(25);
+  const breakMinutes = ref(5);
+  const totalSets = ref(4);
+  const currentSet = ref(1);
+  const phase = ref<'work' | 'break'>('work');
+  const remainingMs = ref(workMinutes.value * 60 * 1000);
+  const isRunning = ref(false);
+  const isPaused = ref(false);
+  const lockSettings = ref(false);
+  let targetAt: number | null = null;
+  let rafId: number | null = null;
+
+  const phaseDuration = computed(() =>
+    (phase.value === 'work' ? workMinutes.value : breakMinutes.value) * 60 * 1000
+  );
+
+  const formattedTime = computed(() => {
+    const totalSec = Math.ceil(remainingMs.value / 1000);
+    const m = String(Math.floor(totalSec / 60)).padStart(2, '0');
+    const s = String(totalSec % 60).padStart(2, '0');
+    return `${m}:${s}`;
+  });
+
+  const progress = computed(() =>
+    ((phaseDuration.value - remainingMs.value) / phaseDuration.value) * 100
+  );
+
+  function tick() {
+    if (!isRunning.value || targetAt === null) return;
+    remainingMs.value = Math.max(0, targetAt - Date.now());
+    if (remainingMs.value <= 0) {
+      nextPhase();
+      return;
+    }
+    rafId = requestAnimationFrame(tick);
+  }
+
+  function start() {
+    if (isRunning.value || isPaused.value) return;
+    lockSettings.value = true;
+    targetAt = Date.now() + remainingMs.value;
+    isRunning.value = true;
+    tick();
+  }
+
+  function pause() {
+    if (!isRunning.value) return;
+    isRunning.value = false;
+    isPaused.value = true;
+    if (rafId) cancelAnimationFrame(rafId);
+    rafId = null;
+  }
+
+  function resume() {
+    if (!isPaused.value) return;
+    targetAt = Date.now() + remainingMs.value;
+    isRunning.value = true;
+    isPaused.value = false;
+    tick();
+  }
+
+  function stop() {
+    if (rafId) cancelAnimationFrame(rafId);
+    rafId = null;
+    isRunning.value = false;
+    isPaused.value = false;
+    targetAt = null;
+    remainingMs.value = phaseDuration.value;
+  }
+
+  function reset() {
+    if (rafId) cancelAnimationFrame(rafId);
+    rafId = null;
+    isRunning.value = false;
+    isPaused.value = false;
+    targetAt = null;
+    phase.value = 'work';
+    currentSet.value = 1;
+    lockSettings.value = false;
+    remainingMs.value = workMinutes.value * 60 * 1000;
+  }
+
+  function nextPhase() {
+    if (phase.value === 'work') {
+      phase.value = 'break';
+      remainingMs.value = breakMinutes.value * 60 * 1000;
+    } else {
+      currentSet.value += 1;
+      if (currentSet.value > totalSets.value) {
+        reset();
+        return;
+      }
+      phase.value = 'work';
+      remainingMs.value = workMinutes.value * 60 * 1000;
+    }
+    targetAt = Date.now() + remainingMs.value;
+    tick();
+  }
+
+  function handleKey(e: KeyboardEvent) {
+    if (e.code === 'Space') {
+      e.preventDefault();
+      if (!isRunning.value && !isPaused.value) start();
+      else if (isRunning.value) pause();
+      else if (isPaused.value) resume();
+    } else if (e.key === 's' || e.key === 'S') {
+      e.preventDefault();
+      stop();
+    } else if (e.key === 'r' || e.key === 'R') {
+      e.preventDefault();
+      reset();
+    } else if (!isRunning.value && !isPaused.value) {
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        if (totalSets.value < 12) totalSets.value++;
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        if (totalSets.value > 1) totalSets.value--;
+      }
+    }
+  }
+
+  onMounted(() => {
+    window.addEventListener('keydown', handleKey);
+  });
+
+  onUnmounted(() => {
+    window.removeEventListener('keydown', handleKey);
+    if (rafId) cancelAnimationFrame(rafId);
+  });
+
+  return {
+    workMinutes,
+    breakMinutes,
+    totalSets,
+    currentSet,
+    phase,
+    remainingMs,
+    phaseDuration,
+    formattedTime,
+    progress,
+    isRunning,
+    isPaused,
+    lockSettings,
+    start,
+    pause,
+    resume,
+    stop,
+    reset,
+  };
+};

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -31,6 +31,12 @@
           <h2 class="text-xl font-semibold">ポケカ在庫管理</h2>
           <p class="text-sm text-gray-500 mt-1">SQLite×TSでローカル管理アプリ</p>
         </NuxtLink>
+
+        <LinkCard
+          to="/pomodoro"
+          title="ポモドーロタイマー"
+          summary="25分作業 / 5分休憩、セット自動進行"
+        />
       </div>
 
       <div class="mt-12 max-w-xl mx-auto bg-white p-6 rounded-xl shadow-md border-t-4 border-orange-400">

--- a/pages/pomodoro.vue
+++ b/pages/pomodoro.vue
@@ -1,0 +1,98 @@
+<template>
+  <main class="min-h-screen p-4 bg-gray-100">
+    <header class="flex justify-between items-center mb-8">
+      <h1 class="text-2xl font-bold">ポモドーロタイマー</h1>
+      <span class="text-gray-500" aria-hidden="true">⚙️</span>
+    </header>
+
+    <section class="text-center space-y-4">
+      <div class="text-7xl font-mono">{{ formattedTime }}</div>
+      <div class="text-xl">{{ phase === 'work' ? '作業' : '休憩' }}</div>
+      <div
+        class="w-full h-4 bg-gray-300 rounded"
+        role="progressbar"
+        :aria-valuenow="phaseDuration - remainingMs"
+        :aria-valuemax="phaseDuration"
+      >
+        <div
+          class="h-4 bg-orange-400 rounded"
+          :style="{ width: progress + '%' }"
+        ></div>
+      </div>
+      <div class="text-sm">{{ currentSet }} / {{ totalSets }}</div>
+    </section>
+
+    <section class="flex justify-center space-x-4 mt-8">
+      <button
+        v-if="!isRunning && !isPaused"
+        @click="start"
+        aria-label="Start"
+        class="px-4 py-2 bg-orange-500 text-white rounded"
+      >
+        Start
+      </button>
+      <button
+        v-if="isRunning"
+        @click="pause"
+        aria-label="Pause"
+        class="px-4 py-2 bg-orange-500 text-white rounded"
+      >
+        Pause
+      </button>
+      <button
+        v-if="isPaused"
+        @click="resume"
+        aria-label="Resume"
+        class="px-4 py-2 bg-orange-500 text-white rounded"
+      >
+        Resume
+      </button>
+      <button
+        @click="stop"
+        aria-label="Stop"
+        class="px-4 py-2 bg-gray-300 rounded"
+      >
+        Stop
+      </button>
+      <button
+        @click="reset"
+        aria-label="Reset"
+        class="px-4 py-2 bg-gray-300 rounded"
+      >
+        Reset
+      </button>
+    </section>
+
+    <section class="mt-8 text-center">
+      <label class="mr-2" for="set-select">セット数:</label>
+      <select
+        id="set-select"
+        v-model.number="totalSets"
+        :disabled="lockSettings"
+        class="border p-2 rounded"
+      >
+        <option v-for="n in 12" :key="n" :value="n">{{ n }}</option>
+      </select>
+    </section>
+  </main>
+</template>
+
+<script setup lang="ts">
+const {
+  totalSets,
+  currentSet,
+  phase,
+  formattedTime,
+  phaseDuration,
+  remainingMs,
+  progress,
+  isRunning,
+  isPaused,
+  lockSettings,
+  start,
+  pause,
+  resume,
+  stop,
+  reset,
+} = usePomodoroTimer();
+</script>


### PR DESCRIPTION
## Summary
- add reusable LinkCard component and index link to Pomodoro timer
- implement basic Pomodoro timer page with timer controls and set selector
- create composable for timer logic with keyboard shortcuts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b54c3836608326845fe158d3f4389a