### PR TITLE
feat: add PWA support and boards link

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,7 @@
 export default defineNuxtConfig({
   ssr: true,
   target: 'static',
+  modules: ['@vite-pwa/nuxt'],
   app: {
     baseURL: '/my-portfolio/',
     head: {
@@ -16,6 +17,29 @@ export default defineNuxtConfig({
     recaptchaSecret: process.env.RECAPTCHA_SECRET,
     public: {
       recaptchaSiteKey: process.env.RECAPTCHA_SITE_KEY
+    }
+  }
+  ,
+  pwa: {
+    manifest: {
+      name: 'Realtime Kanban',
+      short_name: 'Kanban',
+      theme_color: '#f97316',
+      background_color: '#ffffff',
+      display: 'standalone',
+      start_url: '/my-portfolio/',
+      icons: [
+        {
+          src: 'pwa-192x192.png',
+          sizes: '192x192',
+          type: 'image/png'
+        },
+        {
+          src: 'pwa-512x512.png',
+          sizes: '512x512',
+          type: 'image/png'
+        }
+      ]
     }
   }
 })

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "nuxt": "^3.17.2",
+    "@vite-pwa/nuxt": "^0.10.6",
     "vue": "^3.5.13",
     "vue-router": "^4.5.1"
   }

--- a/pages/boards/[id].vue
+++ b/pages/boards/[id].vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="p-4">
+    <h1 class="text-2xl mb-4">Board {{ id }}</h1>
+    <p>リアルタイムカンバンPWAの準備中...</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+const { id } = useRoute().params
+</script>

--- a/pages/boards/index.vue
+++ b/pages/boards/index.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="p-4">
+    <h1 class="text-2xl mb-4">Boards</h1>
+    <ul>
+      <li>
+        <NuxtLink to="/boards/demo" class="text-blue-600 underline">Demo Board</NuxtLink>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -32,6 +32,12 @@
         </NuxtLink>
 
         <LinkCard
+          to="/boards"
+          title="リアルタイムカンバン"
+          summary="共同編集できるToDoボード"
+        />
+
+        <LinkCard
           to="/pomodoro"
           title="ポモドーロタイマー"
           summary="25分作業 / 5分休憩、セット自動進行"


### PR DESCRIPTION
## Summary
- add @vite-pwa/nuxt and manifest config for PWA
- link to new boards page from index
- scaffold boards pages

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b62d88290c8326801ec475708ffa57