### PR TITLE
Add basic Kanban board list and detail functionality

### DIFF
--- a/pages/boards/[id].vue
+++ b/pages/boards/[id].vue
@@ -1,10 +1,31 @@
 <template>
-  <div class="p-4">
-    <h1 class="text-2xl mb-4">Board {{ id }}</h1>
-    <p>リアルタイムカンバンPWAの準備中...</p>
+  <div class="p-4" v-if="board">
+    <h1 class="text-2xl mb-4">{{ board.name }}</h1>
+    <div class="flex gap-4 overflow-x-auto">
+      <div
+        v-for="column in board.columns"
+        :key="column.id"
+        class="w-64 bg-gray-100 p-2 rounded"
+      >
+        <h2 class="font-bold mb-2">{{ column.name }}</h2>
+        <ul>
+          <li
+            v-for="card in column.cards"
+            :key="card.id"
+            class="bg-white p-2 mb-2 rounded shadow"
+          >
+            {{ card.title }}
+          </li>
+        </ul>
+      </div>
+    </div>
   </div>
+  <div v-else class="p-4">Loading...</div>
 </template>
 
 <script setup lang="ts">
-const { id } = useRoute().params
+import type { KanbanBoard } from '~/types/kanban';
+
+const route = useRoute();
+const { data: board } = await useFetch<KanbanBoard>(`/api/boards/${route.params.id}`);
 </script>

--- a/pages/boards/index.vue
+++ b/pages/boards/index.vue
@@ -2,9 +2,17 @@
   <div class="p-4">
     <h1 class="text-2xl mb-4">Boards</h1>
     <ul>
-      <li>
-        <NuxtLink to="/boards/demo" class="text-blue-600 underline">Demo Board</NuxtLink>
+      <li v-for="board in boards" :key="board.id">
+        <NuxtLink :to="`/boards/${board.id}`" class="text-blue-600 underline">
+          {{ board.name }}
+        </NuxtLink>
       </li>
     </ul>
   </div>
 </template>
+
+<script setup lang="ts">
+import type { KanbanBoardSummary } from '~/types/kanban';
+
+const { data: boards } = await useFetch<KanbanBoardSummary[]>('/api/boards');
+</script>

--- a/server/api/boards/[id].get.ts
+++ b/server/api/boards/[id].get.ts
@@ -1,0 +1,11 @@
+import { boards } from './data';
+import { createError } from 'h3';
+
+export default defineEventHandler(event => {
+  const id = event.context.params?.id as string;
+  const board = boards.find(b => b.id === id);
+  if (!board) {
+    throw createError({ statusCode: 404, statusMessage: 'Board not found' });
+  }
+  return board;
+});

--- a/server/api/boards/data.ts
+++ b/server/api/boards/data.ts
@@ -1,0 +1,32 @@
+import type { KanbanBoard } from '~/types/kanban';
+
+export const boards: KanbanBoard[] = [
+  {
+    id: 'demo',
+    name: 'Demo Board',
+    columns: [
+      {
+        id: 'todo',
+        name: 'To Do',
+        cards: [
+          { id: 'task1', title: 'Set up project' },
+          { id: 'task2', title: 'Write documentation' },
+        ],
+      },
+      {
+        id: 'doing',
+        name: 'Doing',
+        cards: [
+          { id: 'task3', title: 'Implement Kanban board' },
+        ],
+      },
+      {
+        id: 'done',
+        name: 'Done',
+        cards: [
+          { id: 'task4', title: 'Initial commit' },
+        ],
+      },
+    ],
+  },
+];

--- a/server/api/boards/index.get.ts
+++ b/server/api/boards/index.get.ts
@@ -1,0 +1,6 @@
+import { boards } from './data';
+import type { KanbanBoardSummary } from '~/types/kanban';
+
+export default defineEventHandler((): KanbanBoardSummary[] => {
+  return boards.map(({ id, name }) => ({ id, name }));
+});

--- a/types/kanban.ts
+++ b/types/kanban.ts
@@ -1,0 +1,18 @@
+export interface KanbanCard {
+  id: string;
+  title: string;
+}
+
+export interface KanbanColumn {
+  id: string;
+  name: string;
+  cards: KanbanCard[];
+}
+
+export interface KanbanBoard {
+  id: string;
+  name: string;
+  columns: KanbanColumn[];
+}
+
+export type KanbanBoardSummary = Omit<KanbanBoard, 'columns'>;


### PR DESCRIPTION
## Summary
- define Kanban board/card/column types
- add API endpoints returning demo board data
- implement board list and detail pages powered by API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b631ea2a58832683fbc5684768de73