### PR TITLE
feat: add sudoku game

### DIFF
--- a/composables/useSudoku.ts
+++ b/composables/useSudoku.ts
@@ -1,0 +1,126 @@
+import { ref, computed } from 'vue';
+
+export interface Cell {
+  value: number | null;
+  given: boolean;
+}
+
+export const useSudoku = () => {
+  const grid = ref<Cell[][]>([]);
+  const solution = ref<number[][]>([]);
+  const selected = ref<{ r: number; c: number } | null>(null);
+
+  function newGame() {
+    const { puzzle, solution: sol } = generateSudoku();
+    grid.value = puzzle.map((row) =>
+      row.map((v) => ({ value: v === 0 ? null : v, given: v !== 0 }))
+    );
+    solution.value = sol;
+    selected.value = null;
+  }
+
+  function select(r: number, c: number) {
+    selected.value = { r, c };
+  }
+
+  function setValue(n: number) {
+    if (!selected.value) return;
+    const cell = grid.value[selected.value.r][selected.value.c];
+    if (cell.given) return;
+    cell.value = n;
+  }
+
+  function clear() {
+    if (!selected.value) return;
+    const cell = grid.value[selected.value.r][selected.value.c];
+    if (cell.given) return;
+    cell.value = null;
+  }
+
+  const isSolved = computed(() =>
+    grid.value.length > 0 &&
+    grid.value.every((row, r) =>
+      row.every((cell, c) => cell.value === solution.value[r][c])
+    )
+  );
+
+  return { grid, selected, select, setValue, clear, newGame, isSolved };
+};
+
+function generateSudoku(): { puzzle: number[][]; solution: number[][] } {
+  const board = Array.from({ length: 9 }, () => Array(9).fill(0));
+  fillBoard(board);
+  const solution = board.map((row) => [...row]);
+  const puzzle = removeNumbers(board);
+  return { puzzle, solution };
+}
+
+function shuffle<T>(arr: T[]): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function fillBoard(board: number[][], pos = 0): boolean {
+  if (pos === 81) return true;
+  const r = Math.floor(pos / 9);
+  const c = pos % 9;
+  if (board[r][c] !== 0) return fillBoard(board, pos + 1);
+  const nums = shuffle([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  for (const n of nums) {
+    if (isSafe(board, r, c, n)) {
+      board[r][c] = n;
+      if (fillBoard(board, pos + 1)) return true;
+      board[r][c] = 0;
+    }
+  }
+  return false;
+}
+
+function isSafe(board: number[][], r: number, c: number, n: number): boolean {
+  for (let i = 0; i < 9; i++) {
+    if (board[r][i] === n || board[i][c] === n) return false;
+  }
+  const br = Math.floor(r / 3) * 3;
+  const bc = Math.floor(c / 3) * 3;
+  for (let i = 0; i < 3; i++) {
+    for (let j = 0; j < 3; j++) {
+      if (board[br + i][bc + j] === n) return false;
+    }
+  }
+  return true;
+}
+
+function solve(board: number[][], pos = 0, count = 0): number {
+  if (count > 1) return count;
+  if (pos === 81) return count + 1;
+  const r = Math.floor(pos / 9);
+  const c = pos % 9;
+  if (board[r][c] !== 0) return solve(board, pos + 1, count);
+  for (let n = 1; n <= 9 && count < 2; n++) {
+    if (isSafe(board, r, c, n)) {
+      board[r][c] = n;
+      count = solve(board, pos + 1, count);
+    }
+  }
+  board[r][c] = 0;
+  return count;
+}
+
+function removeNumbers(board: number[][]) {
+  const puzzle = board.map((row) => [...row]);
+  const positions = shuffle(Array.from({ length: 81 }, (_, i) => i));
+  for (const pos of positions) {
+    const r = Math.floor(pos / 9);
+    const c = pos % 9;
+    const backup = puzzle[r][c];
+    puzzle[r][c] = 0;
+    const copy = puzzle.map((row) => [...row]);
+    if (solve(copy) !== 1) {
+      puzzle[r][c] = backup;
+    }
+  }
+  return puzzle;
+}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -42,6 +42,12 @@
           title="ポモドーロタイマー"
           summary="25分作業 / 5分休憩、セット自動進行"
         />
+
+        <LinkCard
+          to="/sudoku"
+          title="ナンプレ"
+          summary="9x9数独ゲーム"
+        />
       </div>
 
       <div class="mt-12 max-w-xl mx-auto bg-white p-6 rounded-xl shadow-md border-t-4 border-orange-400">

--- a/pages/sudoku.vue
+++ b/pages/sudoku.vue
@@ -1,0 +1,57 @@
+<template>
+  <main class="min-h-screen bg-gray-100 p-4">
+    <div class="max-w-md mx-auto">
+      <h1 class="text-2xl font-bold text-center text-orange-600 mb-4">ナンプレ</h1>
+      <div class="grid grid-cols-9 gap-0 border-2 border-gray-700">
+        <div v-for="(row, r) in grid" :key="r" class="contents">
+          <button
+            v-for="(cell, c) in row"
+            :key="c"
+            @click="select(r, c)"
+            :class="cellClasses(r, c, cell)"
+          >
+            {{ cell.value ?? '' }}
+          </button>
+        </div>
+      </div>
+      <div class="mt-4 grid grid-cols-3 gap-2">
+        <div class="col-span-3 grid grid-cols-9 gap-1">
+          <button
+            v-for="n in 9"
+            :key="n"
+            class="p-2 bg-white rounded shadow"
+            @click="setValue(n)"
+          >
+            {{ n }}
+          </button>
+        </div>
+        <button class="p-2 bg-white rounded shadow" @click="clear">消す</button>
+        <button class="p-2 bg-white rounded shadow" @click="newGame">新規</button>
+        <div class="p-2 flex items-center justify-center col-span-1" :class="isSolved ? 'text-green-600 font-semibold' : 'text-gray-500'">
+          {{ isSolved ? '完成！' : '' }}
+        </div>
+      </div>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useSudoku, Cell } from '~/composables/useSudoku';
+
+const { grid, selected, select, setValue, clear, newGame, isSolved } = useSudoku();
+
+function cellClasses(r: number, c: number, cell: Cell) {
+  return [
+    'w-8 h-8 border border-gray-400 flex items-center justify-center text-sm',
+    cell.given ? 'bg-gray-200' : 'bg-white',
+    selected.value?.r === r && selected.value?.c === c ? 'bg-yellow-200' : '',
+    r % 3 === 0 ? 'border-t-2' : '',
+    c % 3 === 0 ? 'border-l-2' : '',
+    r === 8 ? 'border-b-2' : '',
+    c === 8 ? 'border-r-2' : '',
+  ];
+}
+
+onMounted(() => newGame());
+</script>


### PR DESCRIPTION
## Summary
- add Sudoku game page with 9x9 grid and number pad
- generate puzzles with unique solutions using new composable
- link Sudoku game from home page

## Testing
- `npm test`
- `npm run build` *(fails: nuxt: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6379ec9488326aef26ab7911c8122