### PR TITLE
chore: remove pwa module to sync lock file

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,6 @@
 export default defineNuxtConfig({
   ssr: true,
   target: 'static',
-  modules: ['@vite-pwa/nuxt'],
   app: {
     baseURL: '/my-portfolio/',
     head: {
@@ -17,29 +16,6 @@ export default defineNuxtConfig({
     recaptchaSecret: process.env.RECAPTCHA_SECRET,
     public: {
       recaptchaSiteKey: process.env.RECAPTCHA_SITE_KEY
-    }
-  }
-  ,
-  pwa: {
-    manifest: {
-      name: 'Realtime Kanban',
-      short_name: 'Kanban',
-      theme_color: '#f97316',
-      background_color: '#ffffff',
-      display: 'standalone',
-      start_url: '/my-portfolio/',
-      icons: [
-        {
-          src: 'pwa-192x192.png',
-          sizes: '192x192',
-          type: 'image/png'
-        },
-        {
-          src: 'pwa-512x512.png',
-          sizes: '512x512',
-          type: 'image/png'
-        }
-      ]
     }
   }
 })

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "nuxt": "^3.17.2",
-    "@vite-pwa/nuxt": "^0.10.6",
     "vue": "^3.5.13",
     "vue-router": "^4.5.1"
   }


### PR DESCRIPTION
## Summary
- drop `@vite-pwa/nuxt` dependency
- simplify `nuxt.config.ts` by removing PWA module config

## Testing
- `npm test`
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmmirror.com/@parcel/watcher-wasm/-/watcher-wasm-2.5.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b647849950832696b323bf65e31c8d