### PR TITLE
feat: add real-time kanban board

### DIFF
--- a/pages/boards/[id].vue
+++ b/pages/boards/[id].vue
@@ -8,11 +8,13 @@
         class="w-64 bg-gray-100 p-2 rounded"
       >
         <h2 class="font-bold mb-2">{{ column.name }}</h2>
-        <ul>
+        <ul @dragover.prevent @drop="onDrop(column.id)">
           <li
             v-for="card in column.cards"
             :key="card.id"
             class="bg-white p-2 mb-2 rounded shadow"
+            draggable="true"
+            @dragstart="onDragStart(column.id, card.id)"
           >
             {{ card.title }}
           </li>
@@ -24,8 +26,49 @@
 </template>
 
 <script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from 'vue';
 import type { KanbanBoard } from '~/types/kanban';
 
 const route = useRoute();
 const { data: board } = await useFetch<KanbanBoard>(`/api/boards/${route.params.id}`);
+
+const dragging = ref<{ columnId: string; cardId: string } | null>(null);
+
+const updateBoard = async () => {
+  if (!board.value) return;
+  await $fetch(`/api/boards/${board.value.id}`, {
+    method: 'PUT',
+    body: board.value,
+  });
+};
+
+const onDragStart = (columnId: string, cardId: string) => {
+  dragging.value = { columnId, cardId };
+};
+
+const onDrop = (targetColumnId: string) => {
+  if (!dragging.value || !board.value) return;
+  const { columnId, cardId } = dragging.value;
+  const fromCol = board.value.columns.find(c => c.id === columnId);
+  const toCol = board.value.columns.find(c => c.id === targetColumnId);
+  if (!fromCol || !toCol) return;
+  const idx = fromCol.cards.findIndex(c => c.id === cardId);
+  if (idx === -1) return;
+  const [card] = fromCol.cards.splice(idx, 1);
+  toCol.cards.push(card);
+  dragging.value = null;
+  updateBoard();
+};
+
+let es: EventSource | null = null;
+onMounted(() => {
+  es = new EventSource(`/api/boards/${route.params.id}/stream`);
+  es.onmessage = (e) => {
+    board.value = JSON.parse(e.data);
+  };
+});
+
+onBeforeUnmount(() => {
+  es?.close();
+});
 </script>

--- a/pages/boards/index.vue
+++ b/pages/boards/index.vue
@@ -1,6 +1,16 @@
 <template>
   <div class="p-4">
     <h1 class="text-2xl mb-4">Boards</h1>
+    <form @submit.prevent="createBoard" class="mb-4 flex gap-2">
+      <input
+        v-model="name"
+        placeholder="New board name"
+        class="border p-1 flex-1"
+      />
+      <button type="submit" class="bg-blue-500 text-white px-3 py-1 rounded">
+        Create
+      </button>
+    </form>
     <ul>
       <li v-for="board in boards" :key="board.id">
         <NuxtLink :to="`/boards/${board.id}`" class="text-blue-600 underline">
@@ -12,7 +22,19 @@
 </template>
 
 <script setup lang="ts">
-import type { KanbanBoardSummary } from '~/types/kanban';
+import { ref } from 'vue';
+import type { KanbanBoardSummary, KanbanBoard } from '~/types/kanban';
 
 const { data: boards } = await useFetch<KanbanBoardSummary[]>('/api/boards');
+const name = ref('');
+
+const createBoard = async () => {
+  if (!name.value) return;
+  const board = await $fetch<KanbanBoard>('/api/boards', {
+    method: 'POST',
+    body: { name: name.value },
+  });
+  name.value = '';
+  await navigateTo(`/boards/${board.id}`);
+};
 </script>

--- a/server/api/boards/[id].put.ts
+++ b/server/api/boards/[id].put.ts
@@ -1,0 +1,16 @@
+import { boards } from './data';
+import type { KanbanBoard } from '~/types/kanban';
+import { kanbanEmitter } from '~/server/kanbanEvents';
+import { createError } from 'h3';
+
+export default defineEventHandler(async (event) => {
+  const id = event.context.params!.id as string;
+  const body = await readBody<KanbanBoard>(event);
+  const idx = boards.findIndex(b => b.id === id);
+  if (idx === -1) {
+    throw createError({ statusCode: 404, statusMessage: 'Board not found' });
+  }
+  boards[idx] = body;
+  kanbanEmitter.emit('update', body);
+  return { success: true };
+});

--- a/server/api/boards/[id]/stream.get.ts
+++ b/server/api/boards/[id]/stream.get.ts
@@ -1,0 +1,21 @@
+import { kanbanEmitter } from '~/server/kanbanEvents';
+import { createEventStream, sendStream } from 'h3';
+
+export default defineEventHandler((event) => {
+  const id = event.context.params!.id as string;
+  const stream = createEventStream();
+
+  const handler = (board: any) => {
+    if (board.id === id) {
+      stream.push(JSON.stringify(board));
+    }
+  };
+
+  kanbanEmitter.on('update', handler);
+  event.node.res.on('close', () => {
+    kanbanEmitter.off('update', handler);
+    stream.close();
+  });
+
+  return sendStream(event, stream); 
+});

--- a/server/api/boards/index.post.ts
+++ b/server/api/boards/index.post.ts
@@ -1,0 +1,20 @@
+import { boards } from './data';
+import type { KanbanBoard } from '~/types/kanban';
+import { kanbanEmitter } from '~/server/kanbanEvents';
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody<{ name: string }>(event);
+  const id = Math.random().toString(36).slice(2, 9);
+  const newBoard: KanbanBoard = {
+    id,
+    name: body.name,
+    columns: [
+      { id: 'todo', name: 'To Do', cards: [] },
+      { id: 'doing', name: 'Doing', cards: [] },
+      { id: 'done', name: 'Done', cards: [] },
+    ],
+  };
+  boards.push(newBoard);
+  kanbanEmitter.emit('update', newBoard);
+  return newBoard;
+});

--- a/server/kanbanEvents.ts
+++ b/server/kanbanEvents.ts
@@ -1,0 +1,3 @@
+import { EventEmitter } from 'node:events';
+
+export const kanbanEmitter = new EventEmitter();


### PR DESCRIPTION
## Summary
- allow creating new boards via UI and API
- support drag-and-drop card movement with real-time updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b64b4e74c88326bf3dc34dfda89903