### PR TITLE
Improve Sudoku board layout and highlighting

### DIFF
--- a/components/SudokuBoard.vue
+++ b/components/SudokuBoard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, computed, onMounted } from 'vue';
+import { ref, watch, onMounted } from 'vue';
 import type { Puzzle, Difficulty, Grid9 } from '~/core/types';
 import { generatePuzzle } from '~/core/generator';
 import { findConflicts, isMoveValid } from '~/core/validator';
@@ -84,32 +84,6 @@ function redo() {
   conflicts.value = findConflicts(grid.value);
 }
 
-const rowStyle = computed(() =>
-  selected.value
-    ? {
-        transform: `translateY(${(selected.value.r * 100) / 9}%)`,
-        height: `${100 / 9}%`,
-        width: '100%',
-      }
-    : {}
-);
-const colStyle = computed(() =>
-  selected.value
-    ? {
-        transform: `translateX(${(selected.value.c * 100) / 9}%)`,
-        width: `${100 / 9}%`,
-        height: '100%',
-      }
-    : {}
-);
-
-const solved = computed(
-  () =>
-    grid.value.length > 0 &&
-    puzzle.value !== null &&
-    grid.value.every((row, r) => row.every((v, c) => v === puzzle.value!.grid[r][c]))
-);
-
 function onKey(e: KeyboardEvent) {
   if (!selected.value) return;
   const { r, c } = selected.value;
@@ -127,9 +101,7 @@ function onKey(e: KeyboardEvent) {
     selected.value = { r, c: (c + 1) % 9 };
   } else if ((e.ctrlKey || e.metaKey) && e.key === 'z') {
     undo();
-  } else if (
-    (e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.shiftKey && e.key === 'Z'))
-  ) {
+  } else if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.shiftKey && e.key === 'Z'))) {
     redo();
   }
 }
@@ -148,16 +120,6 @@ onMounted(() => newGame());
       class="relative"
       :style="{ width: 'min(92vw,560px)', height: 'min(92vw,560px)' }"
     >
-      <div
-        class="row-highlight bg-gray-400 opacity-10 absolute"
-        v-if="selected"
-        :style="rowStyle"
-      ></div>
-      <div
-        class="col-highlight bg-gray-400 opacity-10 absolute"
-        v-if="selected"
-        :style="colStyle"
-      ></div>
       <div class="grid grid-cols-9 grid-rows-9 w-full h-full">
         <template v-for="(row, r) in grid" :key="r">
           <button
@@ -171,11 +133,14 @@ onMounted(() => newGame());
               c % 3 === 0 ? 'border-l-2' : '',
               r === 8 ? 'border-b-2' : '',
               c === 8 ? 'border-r-2' : '',
-              selected?.r === r && selected?.c === c ? 'bg-yellow-200' : '',
+              selected?.r === r && selected?.c === c
+                ? 'bg-yellow-200'
+                : selected && (selected.r === r || selected.c === c)
+                  ? 'bg-yellow-100'
+                  : '',
               givens[r][c] ? 'font-bold' : '',
               props.showErrors && conflicts[r][c] ? 'bg-red-200' : '',
-              selected && grid[selected.r][selected.c] !== 0 &&
-              grid[selected.r][selected.c] === cell
+              selected && grid[selected.r][selected.c] !== 0 && grid[selected.r][selected.c] === cell
                 ? 'bg-blue-100'
                 : '',
             ]"
@@ -185,7 +150,7 @@ onMounted(() => newGame());
         </template>
       </div>
     </div>
-    <div class="mt-2 grid grid-cols-5 gap-2" :style="{ width: 'min(92vw,560px)' }">
+    <div class="mt-2 grid grid-cols-12 gap-2" :style="{ width: 'min(92vw,560px)' }">
       <button
         v-for="n in 9"
         :key="n"
@@ -198,13 +163,6 @@ onMounted(() => newGame());
       <button class="p-2 bg-white border rounded" @click="undo">Undo</button>
       <button class="p-2 bg-white border rounded" @click="redo">Redo</button>
     </div>
-    <div class="mt-2" v-if="solved">完成！</div>
   </div>
 </template>
 
-<style scoped>
-.row-highlight,
-.col-highlight {
-  pointer-events: none;
-}
-</style>

--- a/pages/sudoku.vue
+++ b/pages/sudoku.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="p-4">
-    <div class="flex flex-wrap gap-2 items-center mb-4">
+  <div class="min-h-screen p-4 flex flex-col items-center justify-center gap-4">
+    <div class="flex flex-wrap gap-2 items-center justify-center">
       <select v-model="difficulty" class="border p-1">
         <option value="easy">やさしい</option>
         <option value="normal">ふつう</option>
@@ -13,7 +13,7 @@
         <input type="checkbox" v-model="showErrors" /> エラーハイライト
       </label>
       <button class="border p-1" @click="toggleTheme">テーマ切替</button>
-      <div class="ml-auto text-sm flex items-center gap-1">
+      <div class="text-sm flex items-center gap-1">
         Seed: {{ seed }}
         <button class="border px-1" @click="copySeed">コピー</button>
       </div>


### PR DESCRIPTION
## Summary
- Center Sudoku page and streamline controls
- Fix row/column highlighting and arrange keypad in a single row
- Remove completion message for cleaner design

## Testing
- `npm test` *(hangs after running first test)*
- `npx eslint .` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68b660fb15bc832695f03996f5fb372f