### PR TITLE
feat: enable drag and drop moving for kanban

### DIFF
--- a/pages/boards/[id].vue
+++ b/pages/boards/[id].vue
@@ -8,13 +8,13 @@
         class="w-64 bg-gray-100 p-2 rounded"
       >
         <h2 class="font-bold mb-2">{{ column.name }}</h2>
-        <ul @dragover.prevent @drop="onDrop(column.id)">
+        <ul @dragover.prevent @drop.prevent="onDrop(column.id)">
           <li
             v-for="card in column.cards"
             :key="card.id"
             class="bg-white p-2 mb-2 rounded shadow"
             draggable="true"
-            @dragstart="onDragStart(column.id, card.id)"
+            @dragstart="onDragStart(column.id, card.id, $event)"
           >
             {{ card.title }}
           </li>
@@ -42,8 +42,9 @@ const updateBoard = async () => {
   });
 };
 
-const onDragStart = (columnId: string, cardId: string) => {
+const onDragStart = (columnId: string, cardId: string, event: DragEvent) => {
   dragging.value = { columnId, cardId };
+  event.dataTransfer?.setData('text/plain', cardId);
 };
 
 const onDrop = (targetColumnId: string) => {


### PR DESCRIPTION
## Summary
- allow Kanban cards to move between columns with drag and drop

## Testing
- `node --test` *(fails: process hung after initial test output)*
- `npx eslint .` *(fails: could not find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b667c8429c83268139fe9e67193f05