### PR TITLE
refactor landing page style using design tokens

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,9 +1,30 @@
 <script setup lang="ts">
+import '~/assets/css/tokens.css'
+import '~/assets/css/base.css'
+
+onMounted(() => {
+  const root = document.documentElement
+  const mq = window.matchMedia('(prefers-color-scheme: dark)')
+  root.setAttribute('data-theme', mq.matches ? 'dark' : 'light')
+  mq.addEventListener?.('change', e => root.setAttribute('data-theme', e.matches ? 'dark':'light'))
+  window.addEventListener('scroll', () => {
+    document.querySelector('.nav')?.classList.toggle('is-scrolled', window.scrollY>4)
+  })
+})
+
 useHead({
   script: [{ src: 'https://cdn.tailwindcss.com' }]
 })
 </script>
 
 <template>
-  <NuxtPage />
+  <NuxtLayout>
+    <a class="visually-hidden-focusable" href="#content">本文へスキップ</a>
+    <NuxtPage />
+  </NuxtLayout>
 </template>
+
+<style>
+.visually-hidden-focusable{ position:absolute; left:-9999px; top:auto; width:1px; height:1px; overflow:hidden; }
+.visually-hidden-focusable:focus{ position:static; width:auto; height:auto; padding:8px; background:var(--accent); color:var(--accent-contrast); }
+</style>

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,0 +1,51 @@
+@layer base, components, utilities;
+
+/* base */
+@layer base {
+  :root { color-scheme: light dark }
+  html { font-family: var(--font-sans); background: var(--bg); color: var(--fg); }
+  body { margin: 0; }
+  * { box-sizing: border-box; }
+  img { max-width: 100%; height: auto; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
+  .container { width: var(--container-w); margin-inline: auto; padding-inline: var(--space-4); }
+  .section { padding-block: clamp(40px, 6vw, 96px); }
+  .h1 { font-size: clamp(32px, 6vw, 56px); line-height:1.08; letter-spacing:-.01em; font-weight:800; }
+  .h2 { font-size: clamp(24px, 4vw, 36px); line-height:1.15; font-weight:700; margin: 0 0 var(--space-4); }
+  .lead { font-size: clamp(16px, 2.4vw, 20px); color: var(--muted); }
+  @media (prefers-reduced-motion: no-preference) {
+    .reveal { opacity: 0; transform: translateY(8px); transition: opacity .3s ease, transform .3s ease; }
+    .reveal.is-inview { opacity: 1; transform: none; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    * { animation: none !important; transition: none !important; }
+    html { scroll-behavior: auto !important; }
+  }
+}
+
+/* components */
+@layer components {
+  .card { background: var(--surface); border:1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--shadow-1); }
+  .card--hover:hover { box-shadow: var(--shadow-2); transform: translateY(-2px); transition: box-shadow .2s ease, transform .2s ease; }
+  .btn { display:inline-flex; align-items:center; gap:8px; padding:10px 16px; border-radius:12px; border:1px solid var(--border); font-weight:600; }
+  .btn--primary { background: var(--accent); color: var(--accent-contrast); border-color: transparent; }
+  .btn--ghost { background: transparent; color: var(--fg); }
+  .badge { display:inline-block; padding:2px 8px; border-radius:999px; background: var(--surface-2); border:1px solid var(--border); font-size:12px; }
+  .nav { position: sticky; top:0; z-index: 50; backdrop-filter: blur(8px); }
+  .nav__bar { display:flex; align-items:center; justify-content:space-between; height:64px; }
+  .nav.is-scrolled { background: color-mix(in oklab, var(--surface) 80%, transparent); border-bottom:1px solid var(--border); }
+  .hero { padding-block: clamp(48px, 8vw, 128px); }
+  .grid { display:grid; gap: var(--space-5); }
+  @media (min-width: 960px){ .grid--3 { grid-template-columns: repeat(3, 1fr); } }
+  .table { width:100%; border-collapse: collapse; font-variant-numeric: tabular-nums; }
+  .table th, .table td { padding:12px 14px; border-bottom:1px solid var(--border); }
+  .input, .select { width:100%; padding:10px 12px; border-radius:10px; border:1px solid var(--border); background: var(--surface); }
+}
+
+/* utilities */
+@layer utilities {
+  .mt-4{ margin-top: var(--space-4); } .mb-4{ margin-bottom: var(--space-4); }
+  .center { display:grid; place-items:center; }
+}

--- a/assets/css/tokens.css
+++ b/assets/css/tokens.css
@@ -1,0 +1,25 @@
+:root[data-theme="light"]{
+  --bg: #0b0f14;
+  --surface: #ffffff;
+  --surface-2: #f6f8fb;
+  --fg: #0f1726;
+  --muted: #64748b;
+  --border: #e3e8ef;
+  --accent: #2563eb;
+  --accent-contrast:#fff;
+  --radius-sm: 8px; --radius-md: 12px; --radius-lg: 16px; --radius-2xl: 24px;
+  --space-1: 4px; --space-2: 8px; --space-3: 12px; --space-4: 16px; --space-5: 24px; --space-6: 32px;
+  --shadow-1: 0 1px 2px rgba(0,0,0,.06);
+  --shadow-2: 0 4px 12px rgba(0,0,0,.08);
+  --shadow-3: 0 12px 24px rgba(0,0,0,.12);
+  --container-w: min(1200px, 92vw);
+  --font-sans: ui-sans-serif, Inter, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans JP", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+}
+@media (prefers-color-scheme: dark){
+:root[data-theme="dark"]{
+  --bg: #0b0f14; --surface:#0f1726; --surface-2:#0b1220;
+  --fg: #e7eef7; --muted:#9fb0c4; --border:#1f2a3a;
+  --accent:#60a5fa; --accent-contrast:#0b1020;
+  /* その他の変数は同値でOK */
+}}

--- a/components/LinkCard.vue
+++ b/components/LinkCard.vue
@@ -1,13 +1,13 @@
 <template>
   <NuxtLink
     :to="to"
-    class="bg-white border-t-4 border-orange-400 shadow-md p-6 rounded-xl hover:bg-orange-50 hover:-translate-y-1 hover:shadow-xl transition-transform transform flex justify-between items-center"
+    class="card card--hover p-6 flex justify-between items-center"
   >
     <div>
       <h2 class="text-xl font-semibold">{{ title }}</h2>
       <p class="text-sm text-gray-500 mt-1">{{ summary }}</p>
     </div>
-    <span aria-hidden="true" class="text-orange-400 text-2xl">→</span>
+    <span aria-hidden="true" class="text-2xl">→</span>
   </NuxtLink>
 </template>
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,90 +1,102 @@
 <template>
-  <main class="min-h-screen bg-gray-100 p-8">
-    <div class="max-w-4xl mx-auto">
-      <div class="text-center">
-        <h1 class="text-4xl font-bold text-orange-600">Kengo Mukai</h1>
-        <p class="text-gray-700 mt-2">NuxtとTypeScriptで心地よいWeb体験を。</p>
+  <main id="content">
+    <section class="hero section">
+      <div class="container">
+        <div class="text-center">
+          <h1 class="h1 reveal">Kengo Mukai</h1>
+          <p class="lead mt-4 reveal">NuxtとTypeScriptで心地よいWeb体験を。</p>
+        </div>
       </div>
+    </section>
 
-      <div class="mt-10 grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
-        <NuxtLink
-          to="/board"
-          class="bg-white border-t-4 border-orange-400 shadow-md p-6 rounded-xl hover:bg-orange-50 hover:-translate-y-1 hover:shadow-xl transition-transform transform flex justify-between items-center"
-        >
-          <div>
-            <h2 class="text-xl font-semibold">掲示板</h2>
-            <p class="text-sm text-gray-500 mt-1">コミュニティで意見交換</p>
-          </div>
-          <span aria-hidden="true" class="text-orange-400 text-2xl">→</span>
-        </NuxtLink>
+    <section class="section">
+      <div class="container">
+        <div class="grid grid--3">
+          <NuxtLink
+            to="/board"
+            class="card card--hover p-6 flex justify-between items-center reveal"
+          >
+            <div>
+              <h2 class="text-xl font-semibold">掲示板</h2>
+              <p class="text-sm text-gray-500 mt-1">コミュニティで意見交換</p>
+            </div>
+            <span aria-hidden="true" class="text-2xl">→</span>
+          </NuxtLink>
 
-        <NuxtLink
-          to="/projects/weathermood"
-          class="bg-white border-t-4 border-orange-400 shadow-md p-6 rounded-xl hover:bg-orange-50 hover:-translate-y-1 hover:shadow-xl transition-transform transform flex justify-between items-center"
-        >
-          <div>
-            <h2 class="text-xl font-semibold">WeatherMood</h2>
-            <p class="text-sm text-gray-500 mt-1">天気×気分UIで魅せるTypeScript作品</p>
-          </div>
-          <span aria-hidden="true" class="text-orange-400 text-2xl">→</span>
-        </NuxtLink>
+          <NuxtLink
+            to="/projects/weathermood"
+            class="card card--hover p-6 flex justify-between items-center reveal"
+          >
+            <div>
+              <h2 class="text-xl font-semibold">WeatherMood</h2>
+              <p class="text-sm text-gray-500 mt-1">天気×気分UIで魅せるTypeScript作品</p>
+            </div>
+            <span aria-hidden="true" class="text-2xl">→</span>
+          </NuxtLink>
 
-        <NuxtLink
-          to="/projects/pokemon"
-          class="bg-white border-t-4 border-orange-400 shadow-md p-6 rounded-xl hover:bg-orange-50 hover:-translate-y-1 hover:shadow-xl transition-transform transform flex justify-between items-center"
-        >
-          <div>
-            <h2 class="text-xl font-semibold">ポケカ在庫管理</h2>
-            <p class="text-sm text-gray-500 mt-1">SQLite×TSでローカル管理アプリ</p>
-          </div>
-          <span aria-hidden="true" class="text-orange-400 text-2xl">→</span>
-        </NuxtLink>
+          <NuxtLink
+            to="/projects/pokemon"
+            class="card card--hover p-6 flex justify-between items-center reveal"
+          >
+            <div>
+              <h2 class="text-xl font-semibold">ポケカ在庫管理</h2>
+              <p class="text-sm text-gray-500 mt-1">SQLite×TSでローカル管理アプリ</p>
+            </div>
+            <span aria-hidden="true" class="text-2xl">→</span>
+          </NuxtLink>
 
-        <LinkCard
-          to="/boards"
-          title="リアルタイムカンバン"
-          summary="共同編集できるToDoボード"
-        />
+          <LinkCard
+            to="/boards"
+            title="リアルタイムカンバン"
+            summary="共同編集できるToDoボード"
+            class="reveal"
+          />
 
-        <LinkCard
-          to="/pomodoro"
-          title="ポモドーロタイマー"
-          summary="25分作業 / 5分休憩、セット自動進行"
-        />
-
-        <LinkCard
-          to="/sudoku"
-          title="ナンプレ"
-          summary="9x9数独ゲーム"
-        />
+          <LinkCard
+            to="/pomodoro"
+            title="ポモドーロタイマー"
+            summary="25分作業 / 5分休憩、セット自動進行"
+            class="reveal"
+          />
+          <LinkCard
+            to="/sudoku"
+            title="ナンプレ"
+            summary="9x9数独ゲーム"
+            class="reveal"
+          />
+        </div>
       </div>
+    </section>
 
-      <div class="mt-12 max-w-xl mx-auto bg-white p-6 rounded-xl shadow-md border-t-4 border-orange-400">
-        <h2 class="text-2xl font-bold mb-4 text-center text-orange-600">お問い合わせ</h2>
-        <form @submit.prevent="submit" class="space-y-4">
-          <div>
-            <label class="block text-sm font-medium mb-1">名前</label>
-            <input v-model="form.name" type="text" class="w-full border rounded p-2" required />
-          </div>
-          <div>
-            <label class="block text-sm font-medium mb-1">メールアドレス</label>
-            <input v-model="form.email" type="email" class="w-full border rounded p-2" required />
-          </div>
-          <div>
-            <label class="block text-sm font-medium mb-1">メッセージ</label>
-            <textarea v-model="form.message" class="w-full border rounded p-2" rows="4" required></textarea>
-          </div>
-          <!-- Honeypot field for bots -->
-          <input v-model="form.botField" type="text" class="hidden" tabindex="-1" autocomplete="off" />
-          <div class="text-center">
-            <button type="submit" class="bg-orange-500 text-white px-4 py-2 rounded" :disabled="sent">
-              送信
-            </button>
-          </div>
-          <p v-if="sent" class="text-green-600 text-center mt-2">送信しました！</p>
-        </form>
+    <section class="section">
+      <div class="container">
+        <div class="max-w-xl mx-auto card p-6">
+          <h2 class="h2 text-center">お問い合わせ</h2>
+          <form @submit.prevent="submit" class="space-y-4">
+            <div>
+              <label for="name" class="block text-sm font-medium mb-1">名前</label>
+              <input id="name" v-model="form.name" type="text" class="input" required />
+            </div>
+            <div>
+              <label for="email" class="block text-sm font-medium mb-1">メールアドレス</label>
+              <input id="email" v-model="form.email" type="email" class="input" required />
+            </div>
+            <div>
+              <label for="message" class="block text-sm font-medium mb-1">メッセージ</label>
+              <textarea id="message" v-model="form.message" class="input" rows="4" required></textarea>
+            </div>
+            <!-- Honeypot field for bots -->
+            <input v-model="form.botField" type="text" class="hidden" tabindex="-1" autocomplete="off" />
+            <div class="text-center">
+              <button type="submit" class="btn btn--primary" :disabled="sent">
+                送信
+              </button>
+            </div>
+            <p v-if="sent" class="text-green-600 text-center mt-2">送信しました！</p>
+          </form>
+        </div>
       </div>
-    </div>
+    </section>
   </main>
 </template>
 

--- a/plugins/inview.client.ts
+++ b/plugins/inview.client.ts
@@ -1,0 +1,7 @@
+export default defineNuxtPlugin(() => {
+  if (!('IntersectionObserver' in window)) return
+  const io = new IntersectionObserver((entries)=>{
+    entries.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('is-inview'); io.unobserve(e.target) } })
+  },{ rootMargin: '0px 0px -10% 0px' })
+  document.querySelectorAll('.reveal').forEach(el=>io.observe(el))
+})


### PR DESCRIPTION
## Summary
- introduce light/dark design tokens and base component styles
- apply tokens to landing page and contact form with accessible markup
- add intersection observer plugin for scroll-triggered reveal animations

## Testing
- `npm test`
- `npx eslint .` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b669f004848326bc683461cc678102