### PR TITLE
fix: lighten default theme

### DIFF
--- a/assets/css/tokens.css
+++ b/assets/css/tokens.css
@@ -1,5 +1,5 @@
 :root[data-theme="light"]{
-  --bg: #0b0f14;
+  --bg: #ffffff;
   --surface: #ffffff;
   --surface-2: #f6f8fb;
   --fg: #0f1726;


### PR DESCRIPTION
## Summary
- set light theme background to white for brighter visuals

## Testing
- `npx eslint .` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm test` *(ran sample test but process required manual termination)*

------
https://chatgpt.com/codex/tasks/task_e_68b67718370883269c58884795baeaf9