### PR TITLE
Fix reveal plugin and refine Sudoku board

### DIFF
--- a/components/SudokuBoard.vue
+++ b/components/SudokuBoard.vue
@@ -127,10 +127,10 @@ onMounted(() => newGame());
             :key="c"
             @click="select(r, c)"
             :class="[
-              'border border-gray-400 flex items-center justify-center select-none',
+              'border-gray-400 flex items-center justify-center select-none',
               'text-lg',
-              r % 3 === 0 ? 'border-t-2' : '',
-              c % 3 === 0 ? 'border-l-2' : '',
+              r % 3 === 0 ? 'border-t-2' : 'border-t',
+              c % 3 === 0 ? 'border-l-2' : 'border-l',
               r === 8 ? 'border-b-2' : '',
               c === 8 ? 'border-r-2' : '',
               selected?.r === r && selected?.c === c
@@ -160,8 +160,8 @@ onMounted(() => newGame());
         {{ n }}
       </button>
       <button class="p-2 bg-white border rounded" @click="erase">消</button>
-      <button class="p-2 bg-white border rounded" @click="undo">Undo</button>
-      <button class="p-2 bg-white border rounded" @click="redo">Redo</button>
+      <button class="p-2 bg-white border rounded" @click="undo">戻す</button>
+      <button class="p-2 bg-white border rounded" @click="redo">やり直し</button>
     </div>
   </div>
 </template>

--- a/plugins/inview.client.ts
+++ b/plugins/inview.client.ts
@@ -1,7 +1,24 @@
-export default defineNuxtPlugin(() => {
-  if (!('IntersectionObserver' in window)) return
-  const io = new IntersectionObserver((entries)=>{
-    entries.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('is-inview'); io.unobserve(e.target) } })
-  },{ rootMargin: '0px 0px -10% 0px' })
-  document.querySelectorAll('.reveal').forEach(el=>io.observe(el))
-})
+export default defineNuxtPlugin((nuxtApp) => {
+  if (!('IntersectionObserver' in window)) return;
+
+  const io = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((e) => {
+        if (e.isIntersecting) {
+          e.target.classList.add('is-inview');
+          io.unobserve(e.target);
+        }
+      });
+    },
+    { rootMargin: '0px 0px -10% 0px' }
+  );
+
+  const observe = () => {
+    document
+      .querySelectorAll('.reveal:not(.is-inview)')
+      .forEach((el) => io.observe(el));
+  };
+
+  observe();
+  nuxtApp.hook('page:finish', observe);
+});


### PR DESCRIPTION
## Summary
- Re-observe `.reveal` elements after navigation to keep card links visible
- Tighten Sudoku cell layout with clear 3x3 block borders
- Localize undo/redo controls for Sudoku

## Testing
- `npx eslint .` *(fails: ESLint couldn't find a config file)*
- `npm test` *(hangs after initial output)*

------
https://chatgpt.com/codex/tasks/task_e_68b679a9d7d4832690f009a1613918be