### PR TITLE
ナンプレ画面のデザイン統一とダークモード対応

### DIFF
--- a/components/SudokuBoard.vue
+++ b/components/SudokuBoard.vue
@@ -130,25 +130,25 @@ onMounted(() => newGame());
                 :class="[
                   'flex items-center justify-center select-none text-lg',
                   ((Math.floor(r / 3) + Math.floor(c / 3)) % 2 === 0
-                    ? 'bg-gray-50'
-                    : 'bg-white'),
+                    ? 'bg-[var(--surface-2)]'
+                    : 'bg-[var(--surface)]'),
                   r % 3 === 0
-                    ? 'border-t-4 border-t-gray-600'
-                    : 'border-t border-t-gray-400',
+                    ? 'border-t-4 border-t-[var(--fg)]'
+                    : 'border-t border-t-[var(--border)]',
                   c % 3 === 0
-                    ? 'border-l-4 border-l-gray-600'
-                    : 'border-l border-l-gray-400',
-                  r === 8 ? 'border-b-4 border-b-gray-600' : '',
-                  c === 8 ? 'border-r-4 border-r-gray-600' : '',
+                    ? 'border-l-4 border-l-[var(--fg)]'
+                    : 'border-l border-l-[var(--border)]',
+                  r === 8 ? 'border-b-4 border-b-[var(--fg)]' : '',
+                  c === 8 ? 'border-r-4 border-r-[var(--fg)]' : '',
                   selected?.r === r && selected?.c === c
-                    ? 'bg-yellow-200'
+                    ? 'bg-yellow-200 dark:bg-yellow-600'
                     : selected && (selected.r === r || selected.c === c)
-                      ? 'bg-yellow-100'
+                      ? 'bg-yellow-100 dark:bg-yellow-700'
                       : '',
                   givens[r][c] ? 'font-bold' : '',
-                  props.showErrors && conflicts[r][c] ? 'bg-red-200' : '',
+                  props.showErrors && conflicts[r][c] ? 'bg-red-200 dark:bg-red-700' : '',
                   selected && grid[selected.r][selected.c] !== 0 && grid[selected.r][selected.c] === cell
-                    ? 'bg-blue-100'
+                    ? 'bg-blue-100 dark:bg-blue-700'
                     : '',
                 ]"
               >
@@ -159,21 +159,21 @@ onMounted(() => newGame());
       </div>
       <div class="flex flex-col items-center gap-4">
         <div class="flex flex-col gap-2">
-          <button class="p-2 bg-white border rounded w-12 h-12" @click="erase">消</button>
-          <button class="p-2 bg-white border rounded w-12 h-12" @click="undo">戻す</button>
-          <button class="p-2 bg-white border rounded w-12 h-12" @click="redo">やり直し</button>
+          <button class="p-2 bg-[var(--surface)] border border-[var(--border)] rounded w-12 h-12" @click="erase">消</button>
+          <button class="p-2 bg-[var(--surface)] border border-[var(--border)] rounded w-12 h-12" @click="undo">戻す</button>
+          <button class="p-2 bg-[var(--surface)] border border-[var(--border)] rounded w-12 h-12" @click="redo">やり直し</button>
         </div>
         <div class="grid grid-cols-3 gap-2">
           <button
             v-for="n in 9"
             :key="n"
-            class="p-2 bg-white border rounded w-12 h-12 flex items-center justify-center"
+            class="p-2 bg-[var(--surface)] border border-[var(--border)] rounded w-12 h-12 flex items-center justify-center"
             @click="input(n)"
           >
             {{ n }}
           </button>
         </div>
-        <button class="p-2 bg-blue-500 text-white border rounded w-full" @click="newGame">新規ゲーム</button>
+        <button class="p-2 bg-blue-500 dark:bg-blue-600 text-white border border-[var(--border)] rounded w-full" @click="newGame">新規ゲーム</button>
       </div>
     </div>
   </div>

--- a/pages/sudoku.vue
+++ b/pages/sudoku.vue
@@ -5,8 +5,8 @@
         <button
           v-for="d in difficulties"
           :key="d.value"
-          class="px-2 py-1 border rounded"
-          :class="d.value === difficulty ? 'bg-blue-500 text-white' : 'bg-white'"
+          class="px-2 py-1 border border-[var(--border)] rounded"
+          :class="d.value === difficulty ? 'bg-blue-500 text-white dark:bg-blue-600' : 'bg-[var(--surface)]'"
           @click="difficulty = d.value"
         >
           {{ d.label }}
@@ -15,10 +15,10 @@
       <label class="flex items-center gap-1">
         <input type="checkbox" v-model="showErrors" /> エラーハイライト
       </label>
-      <button class="border p-1" @click="toggleTheme">テーマ切替</button>
+      <button class="border border-[var(--border)] p-1 bg-[var(--surface)]" @click="toggleTheme">テーマ切替</button>
       <div class="text-sm flex items-center gap-1">
         Seed: {{ seed }}
-        <button class="border px-1" @click="copySeed">コピー</button>
+        <button class="border border-[var(--border)] px-1 bg-[var(--surface)]" @click="copySeed">コピー</button>
       </div>
     </div>
     <SudokuBoard
@@ -51,7 +51,8 @@ function onNew(p: Puzzle) {
 
 function toggleTheme() {
   const root = document.documentElement;
-  root.classList.toggle('dark');
+  const theme = root.getAttribute('data-theme');
+  root.setAttribute('data-theme', theme === 'dark' ? 'light' : 'dark');
 }
 
 async function copySeed() {


### PR DESCRIPTION
## 概要
- サイト共通のテーマ変数を用いてナンプレのUIを整理
- ダークモードでも数字が見えるよう背景・枠線を調整

## テスト
- `npm test` (solver-count が長時間実行されるため途中で停止)
- `node --test test/validator.test.js`
- `npx eslint .` (設定ファイルなしのためエラー)

------
https://chatgpt.com/codex/tasks/task_e_68b80fb1ba0883269dd6d88d700b3d7a