### PR TITLE
外枠をグレーに変更

### DIFF
--- a/components/SudokuBoard.vue
+++ b/components/SudokuBoard.vue
@@ -124,7 +124,7 @@ onMounted(() => newGame());
         class="relative"
         :style="{ width: 'min(92vw,560px)', height: 'min(92vw,560px)' }"
       >
-        <table class="w-full h-full border-[3px] border-[var(--fg)] border-collapse table-fixed">
+        <table class="w-full h-full border-[3px] border-[var(--muted)] border-collapse table-fixed">
           <tbody>
             <tr v-for="(row, r) in grid" :key="r">
               <td


### PR DESCRIPTION
## Summary
- Sudokuボードの外枠をグレー系のカラーに変更

## Testing
- `npm test` *(途中でハングするため中断)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b91fdccb848326aeca83294cb4ff73