### PR TITLE
Kanbanボードにカード・カラム追加機能を実装

### DIFF
--- a/pages/boards/[id].vue
+++ b/pages/boards/[id].vue
@@ -19,6 +19,37 @@
             {{ card.title }}
           </li>
         </ul>
+        <form @submit.prevent="addCard(column.id)" class="mt-2 flex gap-2">
+          <input
+            v-model="newCardTitle[column.id]"
+            placeholder="New task"
+            class="border p-1 flex-1"
+          />
+          <button
+            type="submit"
+            class="bg-green-500 text-white px-2 py-1 rounded"
+          >
+            Add
+          </button>
+        </form>
+      </div>
+      <div class="w-64">
+        <form
+          @submit.prevent="addColumn"
+          class="bg-gray-100 p-2 rounded flex flex-col gap-2"
+        >
+          <input
+            v-model="newColumnName"
+            placeholder="New column name"
+            class="border p-1"
+          />
+          <button
+            type="submit"
+            class="bg-blue-500 text-white px-2 py-1 rounded"
+          >
+            Add column
+          </button>
+        </form>
       </div>
     </div>
   </div>
@@ -33,6 +64,8 @@ const route = useRoute();
 const { data: board } = await useFetch<KanbanBoard>(`/api/boards/${route.params.id}`);
 
 const dragging = ref<{ columnId: string; cardId: string } | null>(null);
+const newCardTitle = ref<Record<string, string>>({});
+const newColumnName = ref('');
 
 const updateBoard = async () => {
   if (!board.value) return;
@@ -58,6 +91,30 @@ const onDrop = (targetColumnId: string) => {
   const [card] = fromCol.cards.splice(idx, 1);
   toCol.cards.push(card);
   dragging.value = null;
+  updateBoard();
+};
+
+const addCard = (columnId: string) => {
+  if (!board.value) return;
+  const title = newCardTitle.value[columnId]?.trim();
+  if (!title) return;
+  const column = board.value.columns.find(c => c.id === columnId);
+  if (!column) return;
+  column.cards.push({ id: Math.random().toString(36).slice(2, 9), title });
+  newCardTitle.value[column.id] = '';
+  updateBoard();
+};
+
+const addColumn = () => {
+  if (!board.value) return;
+  const name = newColumnName.value.trim();
+  if (!name) return;
+  board.value.columns.push({
+    id: Math.random().toString(36).slice(2, 9),
+    name,
+    cards: [],
+  });
+  newColumnName.value = '';
   updateBoard();
 };
 


### PR DESCRIPTION
## Summary
- ボード内でカードを追加できるフォームを実装
- 新しいカラムを追加できるフォームを追加

## Testing
- `npm run lint`
- `npm test` *(solver-count のテストが長時間実行されるため途中で終了)*

------
https://chatgpt.com/codex/tasks/task_e_68b924290c648326b1cf8ef77f0432a5