### PR TITLE
濃い青の入力値をSudokuに表示

### DIFF
--- a/components/SudokuBoard.vue
+++ b/components/SudokuBoard.vue
@@ -150,6 +150,9 @@ onMounted(() => newGame());
                       ? 'bg-blue-200 dark:bg-blue-700'
                       : '',
                     givens[r][c] ? 'font-bold' : '',
+                    !givens[r][c] && cell !== 0
+                      ? 'text-blue-700 dark:text-blue-400'
+                      : '',
                     selected && grid[selected.r][selected.c] !== 0 && grid[selected.r][selected.c] === cell
                       ? 'bg-blue-100 dark:bg-blue-700'
                       : '',


### PR DESCRIPTION
## 概要
- Sudokuで自分が入力した数字を濃い青色で表示

## テスト
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfd359b0dc832680c3fe7e70c67499