### PR TITLE
掲示板投稿機能の修正

### DIFF
--- a/server/api/board/posts/[id]/comments/index.get.ts
+++ b/server/api/board/posts/[id]/comments/index.get.ts
@@ -1,8 +1,7 @@
-import db from '~/server/db';
-import type { Comment } from '~/types/board';
+import { listComments } from '~/server/boardDb'
+import type { Comment } from '~/types/board'
 
-export default defineEventHandler((event) => {
-  const postId = Number(event.context.params!.id);
-  const stmt = db.prepare<Comment>('SELECT * FROM comments WHERE postId = ? ORDER BY id');
-  return stmt.all(postId);
-});
+export default defineEventHandler((event): Comment[] => {
+  const postId = Number(event.context.params!.id)
+  return listComments(postId)
+})

--- a/server/api/board/posts/[id]/comments/index.post.ts
+++ b/server/api/board/posts/[id]/comments/index.post.ts
@@ -1,9 +1,8 @@
-import db from '~/server/db';
+import { insertComment } from '~/server/boardDb'
 
 export default defineEventHandler(async (event) => {
-  const postId = Number(event.context.params!.id);
-  const body = await readBody<{ body: string }>(event);
-  const stmt = db.prepare('INSERT INTO comments (postId, body) VALUES (?, ?)');
-  const info = stmt.run(postId, body.body);
-  return { id: Number(info.lastInsertRowid) };
-});
+  const postId = Number(event.context.params!.id)
+  const body = await readBody<{ body: string }>(event)
+  const id = insertComment(postId, body.body)
+  return { id }
+})

--- a/server/api/board/posts/index.get.ts
+++ b/server/api/board/posts/index.get.ts
@@ -1,7 +1,6 @@
-import db from '~/server/db';
-import type { Post } from '~/types/board';
+import { listPosts } from '~/server/boardDb'
+import type { Post } from '~/types/board'
 
-export default defineEventHandler(() => {
-  const stmt = db.prepare<Post>('SELECT * FROM posts ORDER BY id DESC');
-  return stmt.all();
-});
+export default defineEventHandler((): Post[] => {
+  return listPosts()
+})

--- a/server/api/board/posts/index.post.ts
+++ b/server/api/board/posts/index.post.ts
@@ -1,12 +1,10 @@
-import db from '~/server/db';
+import { insertPost, insertComment } from '~/server/boardDb'
 
 export default defineEventHandler(async (event) => {
-  const body = await readBody<{ title: string; body?: string }>(event);
-  const postStmt = db.prepare('INSERT INTO posts (title) VALUES (?)');
-  const info = postStmt.run(body.title);
+  const body = await readBody<{ title: string; body?: string }>(event)
+  const id = insertPost(body.title)
   if (body.body && body.body.trim()) {
-    const commentStmt = db.prepare('INSERT INTO comments (postId, body) VALUES (?, ?)');
-    commentStmt.run(info.lastInsertRowid, body.body);
+    insertComment(id, body.body)
   }
-  return { id: Number(info.lastInsertRowid) };
-});
+  return { id }
+})

--- a/server/boardDb.ts
+++ b/server/boardDb.ts
@@ -1,0 +1,56 @@
+import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import type { Post, Comment } from '~/types/board'
+
+const dbFile = join(process.cwd(), 'board.json')
+
+interface Data {
+  posts: Post[]
+  comments: Comment[]
+}
+
+function readData(): Data {
+  if (!existsSync(dbFile)) {
+    return { posts: [], comments: [] }
+  }
+  try {
+    const data = JSON.parse(readFileSync(dbFile, 'utf-8')) as Partial<Data>
+    return { posts: data.posts ?? [], comments: data.comments ?? [] }
+  } catch {
+    return { posts: [], comments: [] }
+  }
+}
+
+function writeData(data: Data) {
+  writeFileSync(dbFile, JSON.stringify(data, null, 2))
+}
+
+function nextId(items: { id: number }[]): number {
+  return items.length ? Math.max(...items.map(i => i.id)) + 1 : 1
+}
+
+export function listPosts(): Post[] {
+  const data = readData()
+  return data.posts.sort((a, b) => b.id - a.id)
+}
+
+export function insertPost(title: string): number {
+  const data = readData()
+  const id = nextId(data.posts)
+  data.posts.push({ id, title })
+  writeData(data)
+  return id
+}
+
+export function listComments(postId: number): Comment[] {
+  const data = readData()
+  return data.comments.filter(c => c.postId === postId).sort((a, b) => a.id - b.id)
+}
+
+export function insertComment(postId: number, body: string): number {
+  const data = readData()
+  const id = nextId(data.comments)
+  data.comments.push({ id, postId, body })
+  writeData(data)
+  return id
+}


### PR DESCRIPTION
## 概要
- 掲示板投稿・コメント用の簡易DBを追加
- APIを修正し、新規投稿とコメントが保存できるよう対応

## テスト
- `npm test` (未終了のため手動停止)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfd7f6b9048326a7f028fbc57c22b4