### PR TITLE
Adjust workflows to operate without pnpm lock file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
       - name: Prepare database
         run: pnpm prisma migrate deploy --schema prisma/schema.prisma
       - name: Lint

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,19 +10,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --no-frozen-lockfile
 
       - name: Generate static site
-        run: npm run generate
+        run: pnpm generate
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
## Summary
- update the CI workflow so `actions/setup-node` no longer requires a pnpm lock file and installs with `--no-frozen-lockfile`
- switch the deploy workflow to pnpm, matching the CI install behaviour and upgrading the checked-out actions

## Testing
- `pnpm lint` *(fails: missing eslint-plugin-vue in the offline environment)*
- `pnpm test` *(fails: vitest binary unavailable in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca234361ec8326af2743f99b063757