### PR TITLE
fix: update vitest coverage dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^22.10.1",
     "@typescript-eslint/eslint-plugin": "^8.13.0",
     "@typescript-eslint/parser": "^8.13.0",
-    "@vitest/coverage-c8": "^2.1.6",
+    "@vitest/coverage-v8": "^2.1.6",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.13.0",
     "eslint-config-prettier": "^9.1.0",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./vitest.setup.ts'],
     coverage: {
+      provider: 'v8',
       reporter: ['text', 'html'],
       exclude: ['playwright/**']
     }


### PR DESCRIPTION
## Summary
- replace the unavailable @vitest/coverage-c8 package with the v8 coverage provider that matches Vitest 2
- configure Vitest to explicitly use the v8 coverage provider

## Testing
- pnpm lint *(fails: missing dependencies due to registry 403 while installing packages)*
- pnpm test *(fails: vitest binary unavailable because dependencies cannot be installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca27924f808326adeebd1d63fa7128