### PR TITLE
Fix Nuxt CLI to prefer wasm parser bindings

### DIFF
--- a/scripts/run-nuxt.mjs
+++ b/scripts/run-nuxt.mjs
@@ -5,6 +5,11 @@ import { dirname, resolve as resolvePath } from 'node:path';
 const FORCE_WASM_FLAGS = {
   OXC_PARSER_FORCE_WASM: '1',
   OXC_PARSER_ALLOW_WASM: 'true',
+  OXC_PARSER_ENGINE: 'wasm',
+  OXC_PARSER_SKIP_NATIVE: 'true',
+  OXC_PARSER_DISABLE_NATIVE: '1',
+  NUXT_FORCE_OXC_PARSER_WASM: 'true',
+  NUXT_CLI_FORCE_WASM: 'true',
 };
 
 for (const [key, value] of Object.entries(FORCE_WASM_FLAGS)) {


### PR DESCRIPTION
## Summary
- ensure the custom Nuxt runner exports additional environment flags so the CLI always falls back to the wasm parser when native bindings are unavailable

## Testing
- pnpm lint *(fails: missing local node_modules in the execution environment)*
- pnpm test *(fails: vitest executable missing because dependencies could not be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da2fcb695c8326b1c1a63eca359b98